### PR TITLE
Bug/offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* properly handles offset in limitQuery
+
 ## [1.11.1] 08-03-2017
 ### Fixed
 * added is sql operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-* properly handles offset in limitQuery
+* properly handle offset
 
 ## [1.12.0] - 08-14-2017
 ### Added

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -26,13 +26,18 @@ function aggregateQuery (features, query, options) {
 }
 
 function limitQuery (features, query, options) {
-  const filtered = []
+  let filtered = []
+  if (options.offset) {
+    if (options.offset >= features.length) throw new Error('OFFSET >= features length: ' + options)
+    options.limit += options.offset
+  }
   features.some((feature, i) => {
     const result = processQuery(feature, query, options, i)
     if (result) filtered.push(result)
     return filtered.length === options.limit
   })
-  return finishQuery(filtered, options)
+  if (options.offset) filtered = filtered.slice(options.offset)
+  return finishQuery(filtered, options, query)
 }
 
 function standardQuery (features, query, options) {
@@ -68,7 +73,7 @@ function esriFy (result, options, i) {
   return result
 }
 
-function finishQuery (features, options) {
+function finishQuery (features, options, query) {
   if (options.groupBy) {
     return features
   } else if (options.aggregates) {

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -37,7 +37,7 @@ function limitQuery (features, query, options) {
     return filtered.length === options.limit
   })
   if (options.offset) filtered = filtered.slice(options.offset)
-  return finishQuery(filtered, options, query)
+  return finishQuery(filtered, options)
 }
 
 function standardQuery (features, query, options) {

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -36,7 +36,6 @@ function limitQuery (features, query, options) {
     if (result) filtered.push(result)
     return filtered.length === options.limit
   })
-  if (options.offset) filtered = filtered.slice(options.offset)
   return finishQuery(filtered, options)
 }
 
@@ -74,6 +73,10 @@ function esriFy (result, options, i) {
 }
 
 function finishQuery (features, options) {
+  if (options.offset) {
+    if (options.offset >= features.length) throw new Error('OFFSET >= features length: ' + options)
+    features = features.slice(options.offset)
+  }
   if (options.groupBy) {
     return features
   } else if (options.aggregates) {

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -73,7 +73,7 @@ function esriFy (result, options, i) {
   return result
 }
 
-function finishQuery (features, options, query) {
+function finishQuery (features, options) {
   if (options.groupBy) {
     return features
   } else if (options.aggregates) {

--- a/src/query.js
+++ b/src/query.js
@@ -15,7 +15,7 @@ function create (options) {
   if (options.geometry && where) query += ` AND ${geomFilter}`
   if (options.order || options.orderByFields) query += order
   if (options.limit) query += ` LIMIT ${options.limit}`
-  // if (options.offset) query += ` OFFSET ${options.offset}`
+  // if (options.offset) query += ` OFFSET ${options.offset}` // handled in executeQuery.js
   return query
 }
 

--- a/src/query.js
+++ b/src/query.js
@@ -15,7 +15,7 @@ function create (options) {
   if (options.geometry && where) query += ` AND ${geomFilter}`
   if (options.order || options.orderByFields) query += order
   if (options.limit) query += ` LIMIT ${options.limit}`
-  if (options.offset) query += ` OFFSET ${options.offset}`
+  // if (options.offset) query += ` OFFSET ${options.offset}`
   return query
 }
 

--- a/test/filter.js
+++ b/test/filter.js
@@ -275,6 +275,19 @@ test('With a where and a geometry option', t => {
   run('trees', options, 2315, t)
 })
 
+test('with a where, geometry, limit and offset option', t => {
+  const options = {
+    where: "Genus like '%Quercus%'",
+    geometry: {
+      type: 'Polygon',
+      coordinates: [[[-118.163, 34.162], [-118.108, 34.162], [-118.108, 34.173], [-118.163, 34.173], [-118.163, 34.162]]]
+    },
+    limit: 4,
+    offset: 1
+  }
+  run('trees', options, 4, t)
+})
+
 test('With an envelope, an inSR and an outSR', t => {
   const options = {
     f: 'json',

--- a/test/filter.js
+++ b/test/filter.js
@@ -282,7 +282,70 @@ test('With a where and a geometry option', t => {
   run('trees', options, 2315, t)
 })
 
-test('with a where, geometry, limit and offset option', t => {
+test('With a limit option', t => {
+  t.plan(3)
+  const data = 'trees'
+  const options = {
+    limit: 10
+  }
+  const features = require(`./fixtures/${data}.json`).features
+  const filtered = winnow.query(features, options)
+  t.equal(filtered.length, 10)
+  t.equal(filtered[0].properties.Common_Name, 'SOUTHERN MAGNOLIA')
+  t.equal(filtered[9].properties.Common_Name, 'WINDMILL PALM')
+})
+
+test('With an offset option', t => {
+  t.plan(3)
+  const data = 'trees'
+  const options = {
+    offset: 10
+  }
+  const features = require(`./fixtures/${data}.json`).features
+  const filtered = winnow.query(features, options)
+  t.equal(filtered.length, 71122)
+  t.equal(filtered[0].properties.Common_Name, 'SOUTHERN MAGNOLIA')
+  t.equal(filtered[9].properties.Common_Name, 'JACARANDA')
+})
+
+test('With a limit and an offset option', t => {
+  t.plan(3)
+  const data = 'trees'
+  const options = {
+    limit: 10,
+    offset: 11
+  }
+  const features = require(`./fixtures/${data}.json`).features
+  const filtered = winnow.query(features, options)
+  t.equal(filtered.length, 10)
+  t.equal(filtered[0].properties.Common_Name, 'JACARANDA')
+  t.equal(filtered[9].properties.Common_Name, 'LIVE OAK')
+})
+
+test('With an offset larger than returned features', t => {
+  t.plan(1)
+  const data = 'trees'
+  const options = {
+    offset: 100000
+  }
+  const features = require(`./fixtures/${data}.json`).features
+  t.throws(function () { winnow.query(features, options) })
+})
+
+test('With a limit and an offset larger than returned features', t => {
+  t.plan(1)
+  const data = 'trees'
+  const options = {
+    limit: 10,
+    offset: 100000
+  }
+  const features = require(`./fixtures/${data}.json`).features
+  t.throws(function () { winnow.query(features, options) })
+})
+
+test('With a where, geometry, limit and offset option', t => {
+  t.plan(5)
+  const data = 'trees'
   const options = {
     where: "Genus like '%Quercus%'",
     geometry: {
@@ -292,7 +355,13 @@ test('with a where, geometry, limit and offset option', t => {
     limit: 4,
     offset: 1
   }
-  run('trees', options, 4, t)
+  const features = require(`./fixtures/${data}.json`).features
+  const filtered = winnow.query(features, options)
+  t.equal(filtered.length, 4)
+  t.equal(filtered[0].properties.Common_Name, 'LIVE OAK')
+  t.equal(filtered[0].properties.Trunk_Diameter, 1)
+  t.equal(filtered[3].properties.Common_Name, 'LIVE OAK')
+  t.equal(filtered[3].properties.Trunk_Diameter, 18)
 })
 
 test('With an envelope, an inSR and an outSR', t => {


### PR DESCRIPTION
should fix issues when including offset option. It was not previously tested. `offset` is removed from query building, but is checked in `limitQuery`. Within `limitQuery`, the offset amount is added to `limit` and then sliced once features are filtered.