### PR TITLE
Feature / Use AST to translate WHERE clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@turf/centroid": "^5.0.4",
     "alasql": "^0.4.0",
     "classybrew": "0.0.3",
+    "flora-sql-parser": "^0.7.5",
     "highland": "^3.0.0-beta.3",
     "lodash": "^4.17.4",
     "moment": "^2.18.1",

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -1,0 +1,32 @@
+const test = require('tape')
+const Winnow = require('../src')
+
+test('compiling a complex query', t => {
+  try {
+    t.ok(Winnow.prepareQuery({
+      geometry: {
+        xmin: -37237674.195623085,
+        ymin: 676003.5082798181,
+        xmax: 37237674.195623085,
+        ymax: 12416731.052879848,
+        spatialReference: {
+          wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
+        }
+      }
+    }), 'query compiled')
+    t.end()
+  } catch (e) {
+    t.fail(e)
+    t.end()
+  }
+})
+
+test('compiling with several and statements', t => {
+  try {
+    t.ok(Winnow.prepareQuery({where: 'COMPTMENT >= 3010 AND COMPTMENT <= 3155 AND FOREST >= 517 AND FOREST <= 517'}))
+    t.end()
+  } catch (e) {
+    t.fail(e)
+    t.end()
+  }
+})

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -23,7 +23,7 @@ test('compiling a complex query', t => {
 
 test('compiling with several and statements', t => {
   try {
-    t.ok(Winnow.prepareQuery({where: 'COMPTMENT >= 3010 AND COMPTMENT <= 3155 AND FOREST >= 517 AND FOREST <= 517'}))
+    t.ok(Winnow.prepareQuery({where: 'ELEVATION >= 1165 AND ELEVATION <= 4365 AND POP1990 >= 8247 AND POP1990 <= 5700236'}))
     t.end()
   } catch (e) {
     t.fail(e)


### PR DESCRIPTION
This PR will parse the input WHERE clause into AST, instead of doing regex matching, and traverse the tree to generate translated clause. Not many comments are added since the implementation is very straightforwards. No regex hack :-)

From what I can tell from the test running, the speed is the same.

This PR has covered the problem at #53.