### PR TITLE
Prevent date fields from being add to response when not requested

### DIFF
--- a/src/options/index.js
+++ b/src/options/index.js
@@ -30,7 +30,7 @@ function prepare (options, features) {
     projection: normalizeProjection(options),
     classification: normalizeClassification(options)
   })
-  prepared.dateFields = normalizeDateFields(prepared.collection)
+  prepared.dateFields = normalizeDateFields(prepared.collection, prepared.fields)
   if (prepared.where === '1=1') delete prepared.where
   return prepared
 }

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -26,11 +26,21 @@ function normalizeCollection (options, features = []) {
   return collection
 }
 
-function normalizeDateFields (collection) {
+/**
+ * Identify Date-type fields and explicitly add to dateFields array if outFields query param contains
+ * the date field name or if outFields is a wildcard (when outFields=*, preparedFields === undefined)
+ *
+ * @param {Object} collection metadata about the data source
+ * @param String[] preparedFields - single element string array of delimited field names from "outFields" query param
+ */
+function normalizeDateFields (collection, preparedFields) {
   let dateFields = []
   if (collection && collection.metadata && collection.metadata.fields) {
     collection.metadata.fields.forEach((field, i) => {
-      if (field.type === 'Date') dateFields.push(field.name)
+      // If field is a Date and was included in requested fields (or requested fields are wildcard) add to array
+      if (field.type === 'Date' && (preparedFields === undefined || preparedFields.indexOf(field.name) > -1)) {
+        dateFields.push(field.name)
+      }
     })
   }
   return dateFields

--- a/src/options/normalizeSQL.js
+++ b/src/options/normalizeSQL.js
@@ -12,10 +12,16 @@ function normalizeDate (where) {
   return where
 }
 
+/**
+ * Transform the input of requested response fields
+ * @param {Object} options - object that may contain 'fields' or 'outFields' property
+ */
 function normalizeFields (options) {
   const fields = options.fields || options.outFields
   if (fields === '*') return undefined
-  return typeof fields === 'string' ? [fields] : fields
+  if (typeof fields === 'string' || fields instanceof String) return fields.split(',')
+  if (fields instanceof Array) return fields
+  return undefined
 }
 
 function normalizeOrder (options) {


### PR DESCRIPTION
Discovered that date fields were being add to response payloads even in cases where said date fields were excluded by use of the `outFields` query parameter.  This caused unwanted drawing/rendering effects in ArcGIS Pro.

Also discovered that `outFields` arriving as a comma delimited string were not being parsed properly in Winnow queries.

This PR includes a fix to parse the `outFields` input if comma-delimited, and additional checks to include date fields in response payloads only when specifically requested with `outFields` query param (or when `outFields=*`).