### PR TITLE
Add Support for timestamp Syntax and BETWEEN operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "winnow",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "Apply sql-like filters to GeoJSON",
   "main": "dist/index.js",
   "directories": {

--- a/src/where.js
+++ b/src/where.js
@@ -101,6 +101,18 @@ function handleValue(node, options) {
   return value
 }
 
+
+/**
+ * Convert a timestamp node to its iso8601 string representation.
+ *
+ * @param  {object} node    AST value node
+ * @param  {object} options winnow options
+ * @return {string}         value string
+ */
+function handleTimestampValue(node, options) {
+  return `'${new Date(node.value).toISOString()}'`
+}
+
 /**
  * Traverse a SQL AST and return its string representation
  * @param  {object} node    AST node
@@ -127,6 +139,8 @@ function traverse(node, options) {
     case 'null':
     case 'bool':
       return handleValue(node, options)
+    case 'timestamp':
+      return handleTimestampValue(node, options)
     default:
       throw new Error('Unrecognized AST node: \n' + JSON.stringify(node, null, 2))
    }

--- a/src/where.js
+++ b/src/where.js
@@ -16,6 +16,8 @@ function handleExpr(node, options) {
   } else if (node.operator === '=' && node.left.value === 1 && node.right.value === 1) {
     // a special case related to arcgis server
     return '1=1'
+  } else if (node.operator === 'BETWEEN') {
+    expr = traverse(node.left, options) + " " + (node.operator) + " " + (traverse(node.right.value[0], options)) + "AND" + (traverse(node.right.value[1], options))
   } else {
     // store the column node for value decoding
 

--- a/test/filter.js
+++ b/test/filter.js
@@ -515,6 +515,13 @@ test('with a timestamp query', t => {
   run('permits', options, 211, t)
 })
 
+test('with a between query', t => {
+  const options = {
+    where: "ISSUE_DATE between timestamp '2017-01-05T00:00:00.000Z' AND timestamp '2017-04-08T23:59:59.000Z'"
+  }
+  run('permits', options, 211, t)
+})
+
 function run (data, options, expected, t) {
   t.plan(1)
   const features = require(`./fixtures/${data}.json`).features

--- a/test/filter.js
+++ b/test/filter.js
@@ -508,6 +508,13 @@ test('with an esri-style date query', t => {
   run('permits', options, 211, t)
 })
 
+test('with a timestamp query', t => {
+  const options = {
+    where: "ISSUE_DATE >= timestamp '2017-01-05'"
+  }
+  run('permits', options, 211, t)
+})
+
 function run (data, options, expected, t) {
   t.plan(1)
   const features = require(`./fixtures/${data}.json`).features


### PR DESCRIPTION
    Add support for date comparisons in WHERE filter.

    Winnow currently processes the 'where' parameter as follows:
    * parse to AST with `flora-sql-parser`
    * traverse AST and produce new SQL where clause
    * pass new where clause to alasql to filter features

    ESRI web maps can generate 'where' parameters that use timestamp literals:

        where created_at > timestamp '2018-03-01 14:01:00'

    The flora-sql-parser is able to parse this correctly into a 'timestamp'
    node, but the traverse function in where.js doesn't recognize this node
    type and throws an exception.

    Web maps can also generate 'between' expressions like:

        where created_at BETWEEN timestamp '2018-03-01' AND timestamp '2018-03-02'

    which is also parsed correctly by flora-sql-parser but is serialized
    back into a string that isn't understood by alasql:

        where created_at BETWEEN ('2018-03-01','2018-03-02')

    This commit adds support for the timestamp node and BETWEEN operator so
    that the resulting where clause syntax is understood by alasql.

    The timestamp node is rendered as an iso8601 timestamp string,
    which can be safely compared. The BETWEEN operator node is rendered
    into the standard SQL syntax.