### PR TITLE
Add null feature check to ST_Intersects

### DIFF
--- a/src/sql.js
+++ b/src/sql.js
@@ -25,8 +25,9 @@ sql.fn.ST_Contains = function (feature = {}, filterGeom = {}) {
 }
 
 sql.fn.ST_Intersects = function (feature = {}, filterGeom = {}) {
+  if (!feature) return false
   if (!(feature.type || feature.coordinates)) feature = convertFromEsri(feature) // TODO: remove ? temporary esri geometry conversion
-  if (!(feature && feature.type && feature.coordinates && feature.coordinates.length > 0)) return false
+  if (!(feature.type && feature.coordinates && feature.coordinates.length > 0)) return false
   if (feature.type === 'Point') return sql.fn.ST_Contains(feature, filterGeom)
   const filter = new Terraformer.Primitive(filterGeom)
   const TfFeature = new Terraformer.Primitive(feature)

--- a/test/filter.js
+++ b/test/filter.js
@@ -152,6 +152,24 @@ test('With an esri style envelope', t => {
   run('trees', options, 29744, t)
 })
 
+test('With an esri style envelope and a missing', t => {
+  const options = {
+    outSr: 4326,
+    inSr: 4326,
+    geometry: {
+      xmin: 0,
+      ymin: 40,
+      xmax: 90,
+      ymax: 85,
+      spatialReference: {
+        wkid: 4326
+      }
+    },
+    esri: true
+  }
+  run('missing-geometry', options, 2, t)
+})
+
 test('With an esri style envelope and wkt string for web mercator', t => {
   const options = {
     geometry: {

--- a/test/filter.js
+++ b/test/filter.js
@@ -152,7 +152,7 @@ test('With an esri style envelope', t => {
   run('trees', options, 29744, t)
 })
 
-test('With an esri style envelope and a missing', t => {
+test('With an esri style envelope and features with missing geometry', t => {
   const options = {
     outSr: 4326,
     inSr: 4326,

--- a/test/fixtures/missing-geometry.json
+++ b/test/fixtures/missing-geometry.json
@@ -1,0 +1,68 @@
+{
+  "objectIdFieldName": "OBJECTID",
+  "globalIdFieldName": "",
+  "hasZ": false,
+  "hasM": false,
+  "geometryType": "esriGeometryPoint",
+  "spatialReference": {
+    "wkid": 4326
+  },
+  "fields": [
+    {
+      "name": "OBJECTID",
+      "type": "esriFieldTypeInteger",
+      "alias": "OBJECTID"
+    },
+    {
+      "name": "COMPANY",
+      "type": "esriFieldTypeString",
+      "alias": "COMPANY",
+      "length": 128
+    },
+    {
+      "name": "AVATAR",
+      "type": "esriFieldTypeString",
+      "alias": "AVATAR",
+      "length": 128
+    }
+  ],
+  "features": [
+    {
+      "attributes": {
+        "OBJECTID": 1,
+        "COMPANY": "TEST1",
+        "AVATAR": null
+      },
+      "geometry": {
+        "x": 8.6241263,
+        "y": 49.8707774
+      }
+    },
+    {
+      "attributes": {
+        "OBJECTID": 2,
+        "COMPANY": "TEST2",
+        "AVATAR": null
+      },
+      "geometry": {
+        "x": 80,
+        "y": 60
+      }
+    },
+    {
+      "attributes": {
+        "OBJECTID": 3,
+        "COMPANY": "TEST3",
+        "AVATAR": null
+      },
+      "geometry": null
+    },
+    {
+      "attributes": {
+        "OBJECTID": 3,
+        "COMPANY": "TEST4",
+        "AVATAR": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Check for `feature === null` on `ST_Intersects` function.  Null feature can be passed if a source feature has a `geometry === null`. 