### PR TITLE
Avoid ObjectID collision in subsequent requests from a given client.

### DIFF
--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -80,7 +80,18 @@ test('adding an object id', t => {
   }
   const fixture = _.cloneDeep(geojson)
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.OBJECTID, 0)
+  t.equal(typeof result.features[0].attributes.OBJECTID, 'number')
+  t.end()
+})
+
+test('adding an object id, multiple queries should produce differnt ids', t => {
+  const options = {
+    toEsri: true
+  }
+  const fixture = _.cloneDeep(geojson)
+  const result1 = Winnow.query(fixture, options)
+  const result2 = Winnow.query(fixture, options)
+  t.notEqual(result1.features[0].attributes.OBJECTID, result2.features[0].attributes.OBJECTID)
   t.end()
 })
 


### PR DESCRIPTION
In response to https://github.com/koopjs/FeatureServer/issues/82

If a feature does not already have an id field, winnow assigns one.  It has, up to this point, used the iterator from a loop for this assignment.  The problem with this is that two different features may get assigned the same ID on separate requests (e.g., panning the map which filters with bounding box).  And since clients may cache data according to IDs, this can lead to faulty rendering (e.g., point doesn't get rendered because it has an ID present in the cache).

The alternative presented here is to create a random numeric prefix to that iterator on each request. ArcGIS Object IDs have a limit of 2147483647. So to create a prefix, I trim digits from that limit based on the length of the maximum iterator value, subtract one from the result, and use that value as a range to select a random number.  The result become a prefix to the loop's iterator, which is assigned as the value of the feature's Object ID.
