### PR TITLE
Support the use of a provider's idField as OBJECTID and provide alternative if not specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@turf/centroid": "^6.0.0",
     "alasql": "^0.4.0",
     "classybrew": "0.0.3",
+    "farmhash": "^2.0.5",
     "flora-sql-parser": "^0.7.5",
     "highland": "^3.0.0-beta.3",
     "lodash": "^4.17.4",

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -34,7 +34,7 @@ function limitQuery (features, query, options) {
     options.limit += options.offset
   }
   features.some((feature, i) => {
-    const result = processQuery(feature, query, options, i)
+    const result = processQuery(feature, query, options)
     if (result) filtered.push(result)
     if (filtered.length === (options.limit + 1)) {
       limitExceeded = true
@@ -53,22 +53,22 @@ function limitQuery (features, query, options) {
 
 function standardQuery (features, query, options) {
   const filtered = features.reduce((filteredFeatures, feature, i) => {
-    const result = processQuery(feature, query, options, i)
+    const result = processQuery(feature, query, options)
     if (result) filteredFeatures.push(result)
     return filteredFeatures
   }, [])
   return finishQuery(filtered, options)
 }
 
-function processQuery (feature, query, options, i) {
+function processQuery (feature, query, options) {
   const params = Query.params([feature], options)
   const result = sql(query, params)[0]
 
-  if (result && options.toEsri) return esriFy(result, options, i)
+  if (result && options.toEsri) return esriFy(result, options)
   else return result
 }
 
-function esriFy (result, options, i) {
+function esriFy (result, options) {
   const idField = options.collection && options.collection.metadata && options.collection.metadata.idField
 
   if (options.dateFields.length) {

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -15,13 +15,6 @@ function normalizeCollection (options, features = []) {
   const collection = _.cloneDeep(options.collection)
   const metadata = collection.metadata || {}
   if (!metadata.fields && features[0]) metadata.fields = detectFieldsType(features[0].properties)
-  let oidField
-  if (features[0]) {
-    oidField = Object.keys(features[0].properties).filter(key => {
-      return /objectid/i.test(key)
-    })[0]
-  }
-  if (oidField && !metadata.idField) metadata.idField = oidField
   collection.metadata = metadata
   return collection
 }

--- a/src/options/normalizeSQL.js
+++ b/src/options/normalizeSQL.js
@@ -17,9 +17,20 @@ function normalizeDate (where) {
  * @param {Object} options - object that may contain 'fields' or 'outFields' property
  */
 function normalizeFields (options) {
-  const fields = options.fields || options.outFields
+  let fields = options.fields || options.outFields
+
+  // TODO: Clearer set of if statements
   if (fields === '*') return undefined
-  if (typeof fields === 'string' || fields instanceof String) return fields.split(',')
+  if (typeof fields === 'string' || fields instanceof String) fields = fields.split(',')
+  if (fields instanceof Array && options.toEsri) {
+    // If idField has been set for use as OBJECTID, we must replace OBJECTID with idField in the query fields
+    let idField = options.collection && options.collection.metadata && options.collection.metadata.idField
+    let objectIdIndex = fields.findIndex((i) => { return i === 'OBJECTID' })
+    if (objectIdIndex > -1 && idField) {
+      fields[objectIdIndex] = idField
+    }
+    return fields
+  }
   if (fields instanceof Array) return fields
   return undefined
 }

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -70,7 +70,6 @@ test('checking if an object id exists', t => {
   const fixture = _.cloneDeep(oidFeature)
   const result = Winnow.query(fixture, options)
   t.equal(result.features[0].attributes.objectid, 1)
-  t.equal(result.metadata.idField, 'objectid')
   t.end()
 })
 
@@ -80,7 +79,7 @@ test('adding an object id', t => {
   }
   const fixture = _.cloneDeep(geojson)
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.OBJECTID, 0)
+  t.equal(result.features[0].attributes.OBJECTID, 971640159)
   t.end()
 })
 


### PR DESCRIPTION
This PR contains following changes:
1. Prevents mutation of a provider's metadata object.  Before this, if a `metadata.idField` had not been set, it was added by winnow and set to OBJECTID. This caused some issues with checking to see if a provider had or had not set the `metadata.idField` for certain code executions.

2. If an `idField` has been set in the provider, use a feature's value for this property as the OBJECTID. Then delete the `idField` property from the feature's attributes - this prevents sending the same data on two attributes (the idField and the OBJECTID)

3. If an `idField` has NOT been set in the provider, create an integer hash from the stringified feature and use that as the OBJECTID.

4. If an `idField` has been set in the provider and is thus used as an OBJECTID, incoming queries that request OBJECTID as  one of the `outFields` need to be remapped to the `idField` so that a proper `SELECT` can occur.
 