### PR TITLE
Create OBJECTID by hashing raw feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* OBJECTID collisions when a provider's `idField` is unspecified.  Now creating a numeric hash for each raw feature
+
 ## [1.13.0] - 04-04-2018
 ### Added
 * Add support for date comparisons in WHERE filter with timestamp Syntax and BETWEEN operator

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@turf/centroid": "^6.0.0",
     "alasql": "^0.4.0",
     "classybrew": "0.0.3",
+    "farmhash": "^2.0.5",
     "flora-sql-parser": "^0.7.5",
     "highland": "^3.0.0-beta.3",
     "lodash": "^4.17.4",

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -80,7 +80,7 @@ test('adding an object id', t => {
   }
   const fixture = _.cloneDeep(geojson)
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.OBJECTID, 0)
+  t.equal(result.features[0].attributes.OBJECTID, 2081706708)
   t.end()
 })
 


### PR DESCRIPTION
If a provider's metadata `idField` is not set, create value of OBJECTID from a numeric hash of the raw feature.