### PR TITLE
Add support for esriSpatialRelEnvelopeIntersects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* support for `esriSpatialRelEnvelopeIntersects`
+
 ## [1.14.0] - 04-17-2018
 ### Fixed
 * OBJECTID collisions when a provider's `idField` is unspecified.  Now creating a numeric hash for each raw feature

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/koopjs/winnow#readme",
   "dependencies": {
-    "@turf/bbox-polygon": "^5.0.0",
+    "@turf/bbox-polygon": "^6.0.1",
     "@turf/centroid": "^6.0.0",
     "alasql": "^0.4.0",
     "classybrew": "0.0.3",

--- a/src/geometry/transform-array.js
+++ b/src/geometry/transform-array.js
@@ -1,4 +1,4 @@
-const bboxPolygon = require('@turf/bbox-polygon')
+const bboxPolygon = require('@turf/bbox-polygon').default
 module.exports = function (array) {
   return bboxPolygon(array).geometry
 }

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -7,7 +7,8 @@ const detectFieldsType = require('../detect-fields-type')
 const esriPredicates = {
   esriSpatialRelContains: 'ST_Contains',
   esriSpatialRelWithin: 'ST_Within',
-  esriSpatialRelIntersects: 'ST_Intersects'
+  esriSpatialRelIntersects: 'ST_Intersects',
+  esriSpatialRelEnvelopeIntersects: 'ST_EnvelopeIntersects'
 }
 
 function normalizeCollection (options, features = []) {

--- a/test/filter.js
+++ b/test/filter.js
@@ -285,6 +285,19 @@ test('With a ST_Within geometry predicate', t => {
   run('states', options, 1, t)
 })
 
+test('With a ST_EnvelopeIntersects geometry predicate', t => {
+  const options = {
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [[-128, 29], [-108, 29], [-108, 50], [-128, 50], [-128, 29]]
+      ]
+    },
+    spatialPredicate: 'ST_EnvelopeIntersects'
+  }
+  run('states', options, 11, t)
+})
+
 test('With a ST_Intersects geometry predicate', t => {
   const options = {
     geometry: {


### PR DESCRIPTION
Add support for esriSpatialRelEnvelopeIntersects (aka, ST_EnvelopeIntersects) and companion test. Upgrade to  turf/bbox-polygon to ^6.0.1.