### PR TITLE
Change truthy-test of coordinate to explicit number-test of both coor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* coordinates not projected when latitude or longitude is 0
+
 ## [1.14.0] - 04-17-2018
 ### Fixed
 * OBJECTID collisions when a provider's `idField` is unspecified.  Now creating a numeric hash for each raw feature

--- a/src/geometry/project-coordinates.js
+++ b/src/geometry/project-coordinates.js
@@ -1,4 +1,5 @@
 const proj4 = require('proj4')
+const _ = require('lodash')
 const transformCoordinates = require('./transform-coordinates')
 
 module.exports = function projectCoordinates (coordinates, options = {}) {
@@ -7,7 +8,7 @@ module.exports = function projectCoordinates (coordinates, options = {}) {
   if (inSR === outSR) return coordinates
 
   return transformCoordinates(coordinates, { inSR, outSR }, (coordinates, options) => {
-    if (coordinates[0]) {
+    if (_.isNumber(coordinates[0]) && _.isNumber(coordinates[1])) {
       return proj4(options.inSR, options.outSR, coordinates)
     } else {
       return coordinates

--- a/test/project-coordinates.js
+++ b/test/project-coordinates.js
@@ -1,0 +1,30 @@
+const test = require('tape')
+const projectCoordinates = require('../src/geometry/project-coordinates')
+
+test('Do not project coordinates if one is null', t => {
+  t.plan(2)
+  const transformed = projectCoordinates([null, 63])
+  t.equal(transformed[0], null, 'not projected')
+  t.equal(transformed[1], 63, 'not projected')
+})
+
+test('Do not project coordinates if both are null', t => {
+  t.plan(2)
+  const transformed = projectCoordinates([null, 63])
+  t.equal(transformed[0], null, 'not projected')
+  t.equal(transformed[1], 63, 'not projected')
+})
+
+test('Do not project coordinates if empty array', t => {
+  t.plan(2)
+  const transformed = projectCoordinates([])
+  t.equal(transformed[0], undefined, 'not projected')
+  t.equal(transformed[1], undefined, 'not projected')
+})
+
+test('Project coordinates correctly', t => {
+  t.plan(2)
+  const transformed = projectCoordinates([0, 63])
+  t.equal(transformed[0], 0, 'projected correctly')
+  t.equal(transformed[1], 9100250.907059547, 'projected correctly')
+})


### PR DESCRIPTION
Issue https://github.com/koopjs/koop/issues/309 demostrated problem with projecting coordinates of zero-value.  Tracked this down to truthy-test for null/undefined value in the projectCoordinates function.  Replaced with explicit test for numeric value.  Added unit tests.