### PR TITLE
Have standard.js scan files on npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "standard src && tape test/*.js | tap-spec",
+    "test": "standard && tape test/*.js | tap-spec",
     "clean": "rm -rf dist",
     "compile": "buble -i src -o dist"
   },

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -81,12 +81,11 @@ function esriFy (result, feature, options) {
 
   // If the idField for the model set use its value as OBJECTID
   if (idField) {
-    if (!Number.isInteger(feature.properties[idField]) || feature.properties[idField] > 2147483647 ) {
+    if (!Number.isInteger(feature.properties[idField]) || feature.properties[idField] > 2147483647) {
       console.warn(`WARNING: OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)
     }
     result.attributes.OBJECTID = feature.properties[idField]
-  }
-  else {
+  } else {
     // Create an OBJECTID by creating a numeric hash from the stringified feature
     // Note possibility of OBJECTID collisions with this method still exists, but should be small
     result.attributes.OBJECTID = createIntHash(JSON.stringify(feature))
@@ -113,8 +112,8 @@ function finishQuery (features, options) {
 }
 
 /**
- * Create integer hash in range of 0 - 2147483647 from string 
- * @param {*} inputStr - any string 
+ * Create integer hash in range of 0 - 2147483647 from string
+ * @param {*} inputStr - any string
  */
 function createIntHash (inputStr) {
   // Hash to 32 bit unsigned integer

--- a/src/geometry/utils.js
+++ b/src/geometry/utils.js
@@ -101,25 +101,25 @@ function arraysIntersectArrays (a, b) {
 
 // ported from terraformer-arcgis-parser.js https://github.com/Esri/Terraformer/blob/master/terraformer.js#L502-L512
 function coordinatesContainPoint (coordinates, point) {
-  var contains = false;
+  var contains = false
   for (var i = -1, l = coordinates.length, j = l - 1; ++i < l; j = i) {
     if (((coordinates[i][1] <= point[1] && point[1] < coordinates[j][1]) ||
          (coordinates[j][1] <= point[1] && point[1] < coordinates[i][1])) &&
         (point[0] < (((coordinates[j][0] - coordinates[i][0]) * (point[1] - coordinates[i][1])) / (coordinates[j][1] - coordinates[i][1])) + coordinates[i][0])) {
-      contains = !contains;
+      contains = !contains
     }
   }
-  return contains;
+  return contains
 }
 
 // ported from ported from terraformer-arcgis-parser.js https://github.com/Esri/terraformer-arcgis-parser/blob/master/terraformer-arcgis-parser.js#L159-L166
 function coordinatesContainCoordinates (outer, inner) {
-  var intersects = arraysIntersectArrays(outer, inner);
-  var contains = coordinatesContainPoint(outer, inner[0]);
+  var intersects = arraysIntersectArrays(outer, inner)
+  var contains = coordinatesContainPoint(outer, inner[0])
   if (!intersects && contains) {
-    return true;
+    return true
   }
-  return false;
+  return false
 }
 
 function edgeIntersectsEdge (a1, a2, b1, b2) {

--- a/src/select/fields.js
+++ b/src/select/fields.js
@@ -5,11 +5,9 @@ function createClause (options = {}) {
     let fields
     if (typeof options.fields !== 'string') fields = options.fields.join(',')
     else fields = options.fields.replace(/,\s+/g, ',')
-    if (options.toEsri) { return `pick(properties, "${fields}") as ${propType}` }
-    else { return `type, pick(properties, "${fields}") as ${propType}` }
+    if (options.toEsri) { return `pick(properties, "${fields}") as ${propType}` } else { return `type, pick(properties, "${fields}") as ${propType}` }
   } else {
-    if (options.toEsri) { return `properties as ${propType}` }
-    else { return `type, properties as ${propType}` }
+    if (options.toEsri) { return `properties as ${propType}` } else { return `type, properties as ${propType}` }
   }
 }
 

--- a/src/where.js
+++ b/src/where.js
@@ -1,6 +1,6 @@
-const _ = require('lodash');
-const Parser = require('flora-sql-parser').Parser;
-const parser = new Parser();
+const _ = require('lodash')
+const Parser = require('flora-sql-parser').Parser
+const parser = new Parser()
 
 /**
  * Convert an expression node to its string representation.
@@ -8,8 +8,8 @@ const parser = new Parser();
  * @param  {object} options winnow options
  * @return {string}         expression string
  */
-function handleExpr(node, options) {
-  let expr;
+function handleExpr (node, options) {
+  let expr
 
   if (node.type === 'unary_expr') {
     expr = `${node.operator} ${traverse(node.expr, options)}`
@@ -17,7 +17,7 @@ function handleExpr(node, options) {
     // a special case related to arcgis server
     return '1=1'
   } else if (node.operator === 'BETWEEN') {
-    expr = traverse(node.left, options) + " " + (node.operator) + " " + (traverse(node.right.value[0], options)) + "AND" + (traverse(node.right.value[1], options))
+    expr = traverse(node.left, options) + ' ' + (node.operator) + ' ' + (traverse(node.right.value[0], options)) + 'AND' + (traverse(node.right.value[1], options))
   } else {
     // store the column node for value decoding
 
@@ -45,7 +45,7 @@ function handleExpr(node, options) {
  * @param  {object} options winnow options
  * @return {string}         expression list string
  */
-function handleExprList(node, options) {
+function handleExprList (node, options) {
   const values = node.value.map((valueNode) => traverse(valueNode, options)).join(',')
   return `(${values})`
 }
@@ -56,7 +56,7 @@ function handleExprList(node, options) {
  * @param  {object} options winnow options
  * @return {string}         function string
  */
-function handleFunction(node, options) {
+function handleFunction (node, options) {
   const args = handleExprList(node.args, options)
   return `${node.name}${args}`
 }
@@ -67,7 +67,7 @@ function handleFunction(node, options) {
  * @param  {object} options winnow options
  * @return {string}         column string
  */
-function handleColumn(node, options) {
+function handleColumn (node, options) {
   return options.esri ? `attributes->\`${node.column}\`` : `properties->\`${node.column}\``
 }
 
@@ -81,8 +81,8 @@ function handleColumn(node, options) {
  * @param  {object} options winnow options
  * @return {string}         value string
  */
-function handleValue(node, options) {
-  let value = node.value;
+function handleValue (node, options) {
+  let value = node.value
 
   if (node.columnNode) {
     const field = _.find(options.esriFields, { name: node.columnNode.column })
@@ -103,7 +103,6 @@ function handleValue(node, options) {
   return value
 }
 
-
 /**
  * Convert a timestamp node to its iso8601 string representation.
  *
@@ -111,7 +110,7 @@ function handleValue(node, options) {
  * @param  {object} options winnow options
  * @return {string}         value string
  */
-function handleTimestampValue(node, options) {
+function handleTimestampValue (node, options) {
   return `'${new Date(node.value).toISOString()}'`
 }
 
@@ -121,12 +120,12 @@ function handleTimestampValue(node, options) {
  * @param  {object} options winnow options
  * @return {string}         AST string
  */
-function traverse(node, options) {
+function traverse (node, options) {
   if (!node) {
     return ''
   }
 
-  switch(node.type) {
+  switch (node.type) {
     case 'unary_expr':
     case 'binary_expr':
       return handleExpr(node, options)
@@ -145,7 +144,7 @@ function traverse(node, options) {
       return handleTimestampValue(node, options)
     default:
       throw new Error('Unrecognized AST node: \n' + JSON.stringify(node, null, 2))
-   }
+  }
 }
 
 /**
@@ -153,7 +152,7 @@ function traverse(node, options) {
  * @param  {string} options winnow options
  * @return {string}         SQL where clause
  */
-function createClause(options) {
+function createClause (options) {
   options = options || {}
   if (!options.where) return ''
 


### PR DESCRIPTION
Discovered `standard` was not scanning files properly on `npm test`.  Specifically,  `standard src` was not picking up style errors in files of the `src` directory.  When `standard` was run without `src` a number of style issues were reported.  Those style issues were also fixed in this commit.