### PR TITLE
Handle inSR options that arrive as objects.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/koopjs/winnow#readme",
   "dependencies": {
+    "@esri/proj-codes": "^1.0.4",
     "@turf/bbox-polygon": "^6.0.1",
     "@turf/centroid": "^6.0.0",
     "alasql": "^0.4.0",

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -12,13 +12,15 @@ const {
   normalizeLimit,
   normalizeGeometry,
   normalizeOffset,
-  normalizeProjection } = require('./normalizeOptions')
+  normalizeProjection,
+  normalizeInSR } = require('./normalizeOptions')
 const { normalizeClassification } = require('./normalizeClassification')
 
 function prepare (options, features) {
   const prepared = _.merge({}, options, {
     collection: normalizeCollection(options, features),
     where: normalizeWhere(options),
+    inSR: normalizeInSR(options),
     geometry: normalizeGeometry(options),
     spatialPredicate: normalizeSpatialPredicate(options),
     fields: normalizeFields(options),

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -13,7 +13,8 @@ const {
   normalizeGeometry,
   normalizeOffset,
   normalizeProjection,
-  normalizeInSR } = require('./normalizeOptions')
+  normalizeInSR
+} = require('./normalizeOptions')
 const { normalizeClassification } = require('./normalizeClassification')
 
 function prepare (options, features) {

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -74,6 +74,11 @@ function normalizeGeometry (options) {
   return geometry
 }
 
+/**
+ * Normalize the input spatial reference. Look on options.geometry object first.  If spatial reference not present, look in options.inSR
+ * @param {object} options options object that may or may not have "geometry" and "inSR" properties
+ * @returns {string} formatted string, "EPSG:<wkid>"
+ */
 function normalizeInSR (options) {
   let spatialReference
   // Look for in geometry option's spatial reference

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const projCodes = require('@esri/proj-codes')
 const convertFromEsri = require('../geometry/convert-from-esri')
 const transformArray = require('../geometry/transform-array')
 const transformEnvelope = require('../geometry/transform-envelope')
@@ -68,26 +69,37 @@ function normalizeGeometry (options) {
   } else if (geometry.x || geometry.rings || geometry.paths || geometry.points) {
     geometry = convertFromEsri(geometry)
   }
-  const inSR = bboxCRS || options.inSR
+  const inSR = bboxCRS || normalizeInSR(options)
   if (inSR) geometry.coordinates = projectCoordinates(geometry.coordinates, { inSR, outSR: 'EPSG:4326' })
   return geometry
 }
 
 function normalizeInSR (options) {
-  let SR
-  if (options.inSR) SR = options.inSR
-  else if (_.has(options, 'geometry.spatialReference')) {
+  let spatialReference
+  // Look for in geometry option's spatial reference
+  if (_.has(options, 'geometry.spatialReference')) {
     if (/WGS_1984_Web_Mercator_Auxiliary_Sphere/.test(options.geometry.spatialReference.wkt)) {
-      SR = 3857
-    } else {
-      SR = options.geometry.spatialReference.latestWkid || options.geometry.spatialReference.wkid
-    }
+      spatialReference = 3857
+    } else spatialReference = options.geometry.spatialReference.latestWkid || options.geometry.spatialReference.wkid
+    // Validate spatial refernce
+  } else if (options) {
+    // test for EPSG string format
+    if (/EPSG:/.test(options.inSR)) spatialReference = options.inSR.match(/EPSG:(.*)/)[1]
+    // inSR may be an object with wkid or latestWkid properties
+    else if (_.isPlainObject(options.inSR)) spatialReference = options.inSR.latestWkid || options.inSR.wkid
+    else spatialReference = options.inSR
   }
 
-  if (/EPSG:/.test(SR)) return SR
-  else if (SR === 102100) return `EPSG:3857`
-  else if (SR) return `EPSG:${SR}`
-  else return 'EPSG:4326'
+  // Undefined spatial reference defaults to 4326
+  if (!spatialReference) return 'EPSG:4326'
+  // Special handling for 102100
+  if (spatialReference === 102100) return 'EPSG:3857'
+  // Validate any other submitted spatial reference.
+  if (projCodes.lookup(spatialReference)) return `EPSG:${spatialReference}`
+  else {
+    console.warn(`WARNING: input spatialReference "${spatialReference}" is invalid. Defaulting to 4326.`)
+    return 'EPSG:4326'
+  }
 }
 
 function normalizeLimit (options) {

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -68,7 +68,7 @@ function normalizeGeometry (options) {
   } else if (geometry.x || geometry.rings || geometry.paths || geometry.points) {
     geometry = convertFromEsri(geometry)
   }
-  const inSR = bboxCRS || normalizeInSR(options)
+  const inSR = bboxCRS || options.inSR
   if (inSR) geometry.coordinates = projectCoordinates(geometry.coordinates, { inSR, outSR: 'EPSG:4326' })
   return geometry
 }
@@ -76,7 +76,7 @@ function normalizeGeometry (options) {
 function normalizeInSR (options) {
   let SR
   if (options.inSR) SR = options.inSR
-  else if (options.geometry.spatialReference) {
+  else if (_.has(options, 'geometry.spatialReference')) {
     if (/WGS_1984_Web_Mercator_Auxiliary_Sphere/.test(options.geometry.spatialReference.wkt)) {
       SR = 3857
     } else {
@@ -122,5 +122,6 @@ module.exports = {
   normalizeLimit,
   normalizeGeometry,
   normalizeOffset,
-  normalizeProjection
+  normalizeProjection,
+  normalizeInSR
 }

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -66,3 +66,38 @@ test('normalize input SR with inSR=102100', t => {
   const inSR = normalizeInSR(options)
   t.equal(inSR, 'EPSG:3857')
 })
+
+test('normalize input SR with inSR={wkid: 102100}', t => {
+  t.plan(1)
+  const options = { inSR: { wkid: 102100 } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:3857')
+})
+
+test('normalize input SR with inSR={latestWkid: 102100}', t => {
+  t.plan(1)
+  const options = { inSR: { latestWkid: 102100 } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:3857')
+})
+
+test('normalize input SR with inSR={wkid: 4629}', t => {
+  t.plan(1)
+  const options = { inSR: { wkid: 4629 } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4629')
+})
+
+test('normalize input SR with inSR={ }', t => {
+  t.plan(1)
+  const options = { inSR: { } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4326')
+})
+
+test('normalize input SR with  bogus inSR={wkid:9999}, default to 4326', t => {
+  t.plan(1)
+  const options = { inSR: { wkid: 9999 } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4326')
+})

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -1,0 +1,68 @@
+const test = require('tape')
+const { normalizeInSR } = require('../src/options/normalizeOptions')
+
+test('normalize input SR with geometry.wkt string', t => {
+  t.plan(1)
+  const options = {
+    geometry: {
+      xmin: 0,
+      ymin: 0,
+      xmax: 1,
+      ymax: 1,
+      spatialReference: {
+        wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
+      }
+    }
+  }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:3857')
+})
+
+test('normalize input SR with geometry.latestWkid', t => {
+  t.plan(1)
+  const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { latestWkid: 4269 } } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4269')
+})
+
+test('normalize input SR with geometry.wkid', t => {
+  t.plan(1)
+  const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { wkid: 4269 } } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4269')
+})
+
+test('normalize input SR with inSR EPSG string', t => {
+  t.plan(1)
+  const options = { inSR: 'EPSG:4269' }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4269')
+})
+
+test('normalize input SR with inSR string', t => {
+  t.plan(1)
+  const options = { inSR: '4269' }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4269')
+})
+
+test('normalize input SR with inSR integer', t => {
+  t.plan(1)
+  const options = { inSR: 4269 }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4269')
+})
+
+test('normalize input SR with undefined inSR', t => {
+  t.plan(1)
+  const options = { }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:4326')
+})
+
+test('normalize input SR with inSR=102100', t => {
+  t.plan(1)
+  const options = { inSR: 102100 }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, 'EPSG:3857')
+})


### PR DESCRIPTION
AGOL issues some queries that send `inSR` as an object with properties `wkid` and or `latestWkid`.  The current `normalizeInSR` function did not expect or handle an object data-type, rather, it expects a string or integer. On receiving an object, in would return a string `EPSG: [Object object]`, causing the request to fail.  Issue reported [here](https://github.com/koopjs/koop-output-geoservices/issues/5).

- Wrote tests to cover functionality of pre-refactor `normalizeInSR`
- Refactored `normalizedInSR`
  - Take spatial reference from `geometry` object if it is defined, as the `inSR` is primarily used to reproject the input geometry to wkid 4326.  
  - Look for and parse `object` type for `inSR`
  - Validate spatial reference code.  If invalid, warn and default to 4326
- Add additional tests to cover cases where `inSR` is an object