### PR TITLE
Add new check for skipping the addition of OBJECTID to attributes.

### DIFF
--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -77,9 +77,12 @@ function esriFy (result, feature, options) {
     })
   }
 
+  // Return unless the OBJECTID field needs to be added to attributes
+  if (!options.returnIdsOnly && (options.fields instanceof Array && !options.fields.includes('OBJECTID'))) return result
+
   const idField = _.get(options, 'collection.metadata.idField')
 
-  // If the idField for the model set use its value as OBJECTID
+  // If the idField for the model is set use its value as OBJECTID
   if (idField) {
     if (!Number.isInteger(feature.properties[idField]) || feature.properties[idField] > 2147483647) {
       console.warn(`WARNING: OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -100,6 +100,32 @@ test('adding an object id', t => {
   t.end()
 })
 
+test('exclude objectid addition when not part of outfields', t => {
+  const options = {
+    toEsri: true,
+    outFields: ['string']
+  }
+  const fixture = _.cloneDeep(geojson)
+  const result = Winnow.query(fixture, options)
+  t.equal(Object.keys(result.features[0].attributes).length, 1)
+  t.equal(result.features[0].attributes.hasOwnProperty('string'), true)
+  t.end()
+})
+
+test('do not exclude objectid when returnIdsOnly = true', t => {
+  const options = {
+    toEsri: true,
+    outFields: ['string'],
+    returnIdsOnly: true
+  }
+  const fixture = _.cloneDeep(geojson)
+  const result = Winnow.query(fixture, options)
+  t.equal(Object.keys(result.features[0].attributes).length, 2)
+  t.equal(result.features[0].attributes.hasOwnProperty('string'), true)
+  t.equal(result.features[0].attributes.hasOwnProperty('OBJECTID'), true)
+  t.end()
+})
+
 test('do not overwrite the object id', t => {
   const options = {
     toEsri: true


### PR DESCRIPTION
OBJECTID was still being added to attributes when `outFields` options specifically excluded it.  This PR adds a check to prevent.