### PR TITLE
Filter non wgs84 source data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+* Add normalization of a `option.sourceSR`; this option identifies the CRS of the source data and defaults to 'EPSG:4326'; 
+* If `option.sourceSR` is defined and geometry filter is defined, the geometry filter is reprojected to the CRS of the source
+* Use srs npm to validate WKT CRS
 * Added additional polygon projection tests
 
 ## [1.15.3] - 06-04-2018

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ngeohash": "^0.6.0",
     "proj4": "^2.3.17",
     "simple-statistics": "^6.0.0",
+    "srs": "^1.2.0",
     "terraformer": "^1.0.7"
   },
   "devDependencies": {

--- a/src/geometry/project-coordinates.js
+++ b/src/geometry/project-coordinates.js
@@ -3,13 +3,13 @@ const _ = require('lodash')
 const transformCoordinates = require('./transform-coordinates')
 
 module.exports = function projectCoordinates (coordinates, options = {}) {
-  const inSR = options.inSR || 'EPSG:4326'
-  const outSR = options.outSR || 'EPSG:3857'
-  if (inSR === outSR) return coordinates
+  const sourceSR = options.sourceSR || 'EPSG:4326'
+  const targetSR = options.targetSR || 'EPSG:3857'
+  if (sourceSR === targetSR) return coordinates
 
-  return transformCoordinates(coordinates, { inSR, outSR }, (coordinates, options) => {
+  return transformCoordinates(coordinates, { sourceSR, targetSR }, (coordinates, options) => {
     if (_.isNumber(coordinates[0]) && _.isNumber(coordinates[1])) {
-      return proj4(options.inSR, options.outSR, coordinates)
+      return proj4(options.sourceSR, options.targetSR, coordinates)
     } else {
       return coordinates
     }

--- a/src/geometry/project-coordinates.js
+++ b/src/geometry/project-coordinates.js
@@ -3,13 +3,13 @@ const _ = require('lodash')
 const transformCoordinates = require('./transform-coordinates')
 
 module.exports = function projectCoordinates (coordinates, options = {}) {
-  const sourceSR = options.sourceSR || 'EPSG:4326'
-  const targetSR = options.targetSR || 'EPSG:3857'
-  if (sourceSR === targetSR) return coordinates
+  const fromSR = options.fromSR || 'EPSG:4326'
+  const toSR = options.toSR || 'EPSG:3857'
+  if (fromSR === toSR) return coordinates
 
-  return transformCoordinates(coordinates, { sourceSR, targetSR }, (coordinates, options) => {
+  return transformCoordinates(coordinates, { fromSR, toSR }, (coordinates, options) => {
     if (_.isNumber(coordinates[0]) && _.isNumber(coordinates[1])) {
-      return proj4(options.sourceSR, options.targetSR, coordinates)
+      return proj4(options.fromSR, options.toSR, coordinates)
     } else {
       return coordinates
     }

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -12,8 +12,7 @@ const {
   normalizeLimit,
   normalizeGeometry,
   normalizeOffset,
-  normalizeProjection,
-  normalizeInSR
+  normalizeProjection
 } = require('./normalizeOptions')
 const { normalizeClassification } = require('./normalizeClassification')
 
@@ -21,7 +20,6 @@ function prepare (options, features) {
   const prepared = _.merge({}, options, {
     collection: normalizeCollection(options, features),
     where: normalizeWhere(options),
-    inSR: normalizeInSR(options),
     geometry: normalizeGeometry(options),
     spatialPredicate: normalizeSpatialPredicate(options),
     fields: normalizeFields(options),

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -71,8 +71,8 @@ function normalizeGeometry (options) {
   }
   const inSR = normalizeInSR(options)
   const geometryFilterSR = bboxCRS || inSR
-  const sourceDataSR = normalizeSourceDataSR(options.sourceDataSR)
-  if (inSR) geometry.coordinates = projectCoordinates(geometry.coordinates, { sourceSR: geometryFilterSR, targetSR: sourceDataSR })
+  const sourceSR = normalizeSourceSR(options.sourceSR)
+  if (inSR) geometry.coordinates = projectCoordinates(geometry.coordinates, { fromSR: geometryFilterSR, toSR: sourceSR })
   return geometry
 }
 
@@ -97,7 +97,7 @@ function normalizeInSR (options) {
  * @param {*} input
  * @returns {string} EPSG:<wkid> or srs WKT; defaults to EPSG:4326
  */
-function normalizeSourceDataSR (input) {
+function normalizeSourceSR (input) {
   let spatialReference = normalizeSR(input)
   if (spatialReference) return ((spatialReference.wkid) ? `EPSG:${spatialReference.wkid}` : spatialReference.wkt)
   return `EPSG:4326`
@@ -176,5 +176,5 @@ module.exports = {
   normalizeProjection,
   normalizeSR,
   normalizeInSR,
-  normalizeSourceDataSR
+  normalizeSourceSR
 }

--- a/src/sql.js
+++ b/src/sql.js
@@ -70,7 +70,7 @@ sql.fn.project = function (geometry, projection) {
   try {
     return {
       type: geometry.type,
-      coordinates: projectCoordinates(geometry.coordinates, { targetSR: projection })
+      coordinates: projectCoordinates(geometry.coordinates, { toSR: projection })
     }
   } catch (e) {
     return null

--- a/src/sql.js
+++ b/src/sql.js
@@ -70,7 +70,7 @@ sql.fn.project = function (geometry, projection) {
   try {
     return {
       type: geometry.type,
-      coordinates: projectCoordinates(geometry.coordinates, { outSR: projection })
+      coordinates: projectCoordinates(geometry.coordinates, { targetSR: projection })
     }
   } catch (e) {
     return null

--- a/test/filter.js
+++ b/test/filter.js
@@ -231,6 +231,36 @@ test('With an esri style envelope with xmin = 0, ans esri features', t => {
   run('startups', options, 2, t)
 })
 
+test('With an esri style envelope in a uncommon with xmin = 0, ans esri features', t => {
+  const options = {
+    geometry: {
+      xmin: 6514066.3001615712419152,
+      ymin: 1887820.5006760144606233,
+      xmax: 6514127.4193187793716788,
+      ymax: 1887997.4401315276045352,
+      spatialReference: {
+        wkt: `PROJCS["NAD_1983_StatePlane_California_V_FIPS_0405_Feet",
+        GEOGCS["GCS_North_American_1983",
+            DATUM["North_American_Datum_1983",
+                SPHEROID["GRS_1980",6378137,298.257222101]],
+            PRIMEM["Greenwich",0],
+            UNIT["Degree",0.017453292519943295]],
+        PROJECTION["Lambert_Conformal_Conic_2SP"],
+        PARAMETER["False_Easting",6561666.666666666],
+        PARAMETER["False_Northing",1640416.666666667],
+        PARAMETER["Central_Meridian",-118],
+        PARAMETER["Standard_Parallel_1",34.03333333333333],
+        PARAMETER["Standard_Parallel_2",35.46666666666667],
+        PARAMETER["Latitude_Of_Origin",33.5],
+        UNIT["Foot_US",0.30480060960121924],
+        AUTHORITY["EPSG","102645"]]`
+      }
+    },
+    esri: true
+  }
+  run('trees', options, 4, t)
+})
+
 test('With a an Esri-style Polygon', t => {
   const options = {
     geometry: {

--- a/test/filter.js
+++ b/test/filter.js
@@ -231,7 +231,7 @@ test('With an esri style envelope with xmin = 0, ans esri features', t => {
   run('startups', options, 2, t)
 })
 
-test('With an esri style envelope in a uncommon with xmin = 0, ans esri features', t => {
+test('With an esri style envelope in EPSG:102645 defined by wkt', t => {
   const options = {
     geometry: {
       xmin: 6514066.3001615712419152,

--- a/test/fixtures/street-trees-102645.json
+++ b/test/fixtures/street-trees-102645.json
@@ -1,0 +1,14 @@
+{
+  "type": "FeatureCollection",
+  "name": "street-trees-102645",
+  "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::102645" } },
+  "features": [
+  { "type": "Feature", "properties": { "OBJECTID": 31724, "Common_Nam": "JACARANDA", "Genus": "JACARANDA", "Species": "MIMOSIFOLIA", "House_Numb": 1999, "Street_Dir": null, "Street_Nam": "MENTONE", "Street_Typ": "AVE", "Street_Suf": null, "Trunk_Diam": 23, "Longitude": -118.15747343, "Latitude": 34.180086872000103 }, "geometry": { "type": "Point", "coordinates": [ 6514038.953486103564501, 1887956.492762538837269 ] } },
+  { "type": "Feature", "properties": { "OBJECTID": 31722, "Common_Nam": "JACARANDA", "Genus": "JACARANDA", "Species": "MIMOSIFOLIA", "House_Numb": 1991, "Street_Dir": null, "Street_Nam": "MENTONE", "Street_Typ": "AVE", "Street_Suf": null, "Trunk_Diam": 19, "Longitude": -118.15747179100001, "Latitude": 34.179981473000097 }, "geometry": { "type": "Point", "coordinates": [ 6514039.389178796671331, 1887918.135223435005173 ] } },
+  { "type": "Feature", "properties": { "OBJECTID": 31723, "Common_Nam": "JACARANDA", "Genus": "JACARANDA", "Species": "MIMOSIFOLIA", "House_Numb": 1996, "Street_Dir": null, "Street_Nam": "MENTONE", "Street_Typ": "AVE", "Street_Suf": null, "Trunk_Diam": 17, "Longitude": -118.157324903, "Latitude": 34.180040354 }, "geometry": { "type": "Point", "coordinates": [ 6514083.84874156396836, 1887939.493448474211618 ] } },
+  { "type": "Feature", "properties": { "OBJECTID": 31720, "Common_Nam": "JACARANDA", "Genus": "JACARANDA", "Species": "MIMOSIFOLIA", "House_Numb": 1980, "Street_Dir": null, "Street_Nam": "MENTONE", "Street_Typ": "AVE", "Street_Suf": null, "Trunk_Diam": 15, "Longitude": -118.15732032, "Latitude": 34.179902619000103 }, "geometry": { "type": "Point", "coordinates": [ 6514085.156479243189096, 1887889.367230779025704 ] } },
+  { "type": "Feature", "properties": { "OBJECTID": 31721, "Common_Nam": "JACARANDA", "Genus": "JACARANDA", "Species": "MIMOSIFOLIA", "House_Numb": 1981, "Street_Dir": null, "Street_Nam": "MENTONE", "Street_Typ": "AVE", "Street_Suf": null, "Trunk_Diam": 18, "Longitude": -118.157470069, "Latitude": 34.179832955000101 }, "geometry": { "type": "Point", "coordinates": [ 6514039.825198765844107, 1887864.086112950462848 ] } },
+  { "type": "Feature", "properties": { "OBJECTID": 31719, "Common_Nam": "JACARANDA", "Genus": "JACARANDA", "Species": "MIMOSIFOLIA", "House_Numb": 1980, "Street_Dir": null, "Street_Nam": "MENTONE", "Street_Typ": "AVE", "Street_Suf": null, "Trunk_Diam": 14, "Longitude": -118.157321544, "Latitude": 34.179787634 }, "geometry": { "type": "Point", "coordinates": [ 6514084.720782318152487, 1887847.522821671096608 ] } }
+  ]
+  }
+  

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -1,103 +1,139 @@
 const test = require('tape')
-const { normalizeInSR } = require('../src/options/normalizeOptions')
+const { normalizeSR, normalizeInSR } = require('../src/options/normalizeOptions')
 
-test('normalize input SR with geometry.wkt string', t => {
+test('normalize SR with a wkid in the known list', t => {
   t.plan(1)
-  const options = {
-    geometry: {
-      xmin: 0,
-      ymin: 0,
-      xmax: 1,
-      ymax: 1,
-      spatialReference: {
-        wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
-      }
-    }
-  }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:3857')
+  const spatialReference = { wkid: 4269 }
+  const SR = normalizeSR(spatialReference)
+  t.equal(SR.wkid, 4269)
 })
 
-test('normalize input SR with geometry.latestWkid', t => {
+test('normalize SR with a Web Mercator wkt string', t => {
   t.plan(1)
-  const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { latestWkid: 4269 } } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4269')
+  const wkt = 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
+  const spatialReference = { wkt }
+  const SR = normalizeSR(spatialReference)
+  t.equal(SR.wkid, 3857)
 })
 
-test('normalize input SR with geometry.wkid', t => {
+test('normalize SR with a EPSG:3857 string', t => {
   t.plan(1)
-  const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { wkid: 4269 } } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4269')
+  const spatialReference = 'EPSG:3857'
+  const SR = normalizeSR(spatialReference)
+  t.equal(SR.wkid, 3857)
 })
 
-test('normalize input SR with inSR EPSG string', t => {
+test('normalize SR with a 3857 number', t => {
   t.plan(1)
-  const options = { inSR: 'EPSG:4269' }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4269')
+  const spatialReference = 3857
+  const SR = normalizeSR(spatialReference)
+  t.equal(SR.wkid, 3857)
 })
 
-test('normalize input SR with inSR string', t => {
+test('normalize SR with a 102100 number', t => {
   t.plan(1)
-  const options = { inSR: '4269' }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4269')
+  const spatialReference = 102100
+  const SR = normalizeSR(spatialReference)
+  t.equal(SR.wkid, 3857)
 })
 
-test('normalize input SR with inSR integer', t => {
-  t.plan(1)
-  const options = { inSR: 4269 }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4269')
-})
+// test('normalize input SR with geometry.wkt string', t => {
+//   t.plan(1)
+//   const options = {
+//     geometry: {
+//       xmin: 0,
+//       ymin: 0,
+//       xmax: 1,
+//       ymax: 1,
+//       spatialReference: {
+//         wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
+//       }
+//     }
+//   }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:3857')
+// })
 
-test('normalize input SR with undefined inSR', t => {
-  t.plan(1)
-  const options = { }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4326')
-})
+// test('normalize input SR with geometry.latestWkid', t => {
+//   t.plan(1)
+//   const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { latestWkid: 4269 } } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4269')
+// })
 
-test('normalize input SR with inSR=102100', t => {
-  t.plan(1)
-  const options = { inSR: 102100 }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:3857')
-})
+// test('normalize input SR with geometry.wkid', t => {
+//   t.plan(1)
+//   const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { wkid: 4269 } } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4269')
+// })
 
-test('normalize input SR with inSR={wkid: 102100}', t => {
-  t.plan(1)
-  const options = { inSR: { wkid: 102100 } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:3857')
-})
+// test('normalize input SR with inSR EPSG string', t => {
+//   t.plan(1)
+//   const options = { inSR: 'EPSG:4269' }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4269')
+// })
 
-test('normalize input SR with inSR={latestWkid: 102100}', t => {
-  t.plan(1)
-  const options = { inSR: { latestWkid: 102100 } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:3857')
-})
+// test('normalize input SR with inSR string', t => {
+//   t.plan(1)
+//   const options = { inSR: '4269' }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4269')
+// })
 
-test('normalize input SR with inSR={wkid: 4629}', t => {
-  t.plan(1)
-  const options = { inSR: { wkid: 4629 } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4629')
-})
+// test('normalize input SR with inSR integer', t => {
+//   t.plan(1)
+//   const options = { inSR: 4269 }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4269')
+// })
 
-test('normalize input SR with inSR={ }', t => {
-  t.plan(1)
-  const options = { inSR: { } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4326')
-})
+// test('normalize input SR with undefined inSR', t => {
+//   t.plan(1)
+//   const options = { }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4326')
+// })
 
-test('normalize input SR with  bogus inSR={wkid:9999}, default to 4326', t => {
-  t.plan(1)
-  const options = { inSR: { wkid: 9999 } }
-  const inSR = normalizeInSR(options)
-  t.equal(inSR, 'EPSG:4326')
-})
+// test('normalize input SR with inSR=102100', t => {
+//   t.plan(1)
+//   const options = { inSR: 102100 }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:3857')
+// })
+
+// test('normalize input SR with inSR={wkid: 102100}', t => {
+//   t.plan(1)
+//   const options = { inSR: { wkid: 102100 } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:3857')
+// })
+
+// test('normalize input SR with inSR={latestWkid: 102100}', t => {
+//   t.plan(1)
+//   const options = { inSR: { latestWkid: 102100 } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:3857')
+// })
+
+// test('normalize input SR with inSR={wkid: 4629}', t => {
+//   t.plan(1)
+//   const options = { inSR: { wkid: 4629 } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4629')
+// })
+
+// test('normalize input SR with inSR={ }', t => {
+//   t.plan(1)
+//   const options = { inSR: { } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4326')
+// })
+
+// test('normalize input SR with  bogus inSR={wkid:9999}, default to 4326', t => {
+//   t.plan(1)
+//   const options = { inSR: { wkid: 9999 } }
+//   const inSR = normalizeInSR(options)
+//   t.equal(inSR, 'EPSG:4326')
+// })

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -1,5 +1,5 @@
 const test = require('tape')
-const { normalizeSR, normalizeInSR, normalizeSourceDataSR } = require('../src/options/normalizeOptions')
+const { normalizeSR, normalizeInSR, normalizeSourceSR } = require('../src/options/normalizeOptions')
 
 test('normalize SR with a wkid in the known list', t => {
   t.plan(1)
@@ -142,20 +142,20 @@ test('normalize input SR with  bogus inSR={wkid:9999}, default to 4326', t => {
   t.equal(inSR, `EPSG:4326`)
 })
 
-test('normalize source data SR with sourceDataSR string', t => {
+test('normalize source data SR with sourceSR string', t => {
   t.plan(1)
-  const sourceSR = normalizeSourceDataSR('4269')
+  const sourceSR = normalizeSourceSR('4269')
   t.equal(sourceSR, `EPSG:4269`)
 })
 
-test('normalize source data SR with undefined sourceDataSR', t => {
+test('normalize source data SR with undefined sourceSR', t => {
   t.plan(1)
   const options = { }
   const sourceSR = normalizeInSR(options)
   t.equal(sourceSR, `EPSG:4326`)
 })
 
-test('normalize source data SR with sourceDataSR={ }', t => {
+test('normalize source data SR with sourceSR={ }', t => {
   t.plan(1)
   const options = { inSR: { } }
   const sourceSR = normalizeInSR(options)

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -1,139 +1,170 @@
 const test = require('tape')
-const { normalizeSR, normalizeInSR } = require('../src/options/normalizeOptions')
+const { normalizeSR, normalizeInSR, normalizeSourceDataSR } = require('../src/options/normalizeOptions')
 
 test('normalize SR with a wkid in the known list', t => {
   t.plan(1)
-  const spatialReference = { wkid: 4269 }
-  const SR = normalizeSR(spatialReference)
+  const SR = normalizeSR({ wkid: 4269 })
   t.equal(SR.wkid, 4269)
+})
+
+test('normalize SR with a latest wkid in the known list', t => {
+  t.plan(1)
+  const SR = normalizeSR({ latestWkid: 4269 })
+  t.equal(SR.wkid, 4269)
+})
+
+test('normalize SR with a Web Mercator wkt string in an object', t => {
+  t.plan(1)
+  const wkt = 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
+  const SR = normalizeSR({ wkt })
+  t.equal(SR.wkid, 3857)
 })
 
 test('normalize SR with a Web Mercator wkt string', t => {
   t.plan(1)
   const wkt = 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
-  const spatialReference = { wkt }
-  const SR = normalizeSR(spatialReference)
+  const SR = normalizeSR(wkt)
   t.equal(SR.wkid, 3857)
+})
+
+test('normalize SR with a wkt string', t => {
+  t.plan(1)
+  const wkt = `PROJCS["NAD_1983_StatePlane_California_V_FIPS_0405_Feet",
+  GEOGCS["GCS_North_American_1983",
+      DATUM["North_American_Datum_1983",
+          SPHEROID["GRS_1980",6378137,298.257222101]],
+      PRIMEM["Greenwich",0],
+      UNIT["Degree",0.017453292519943295]],
+  PROJECTION["Lambert_Conformal_Conic_2SP"],
+  PARAMETER["False_Easting",6561666.666666666],
+  PARAMETER["False_Northing",1640416.666666667],
+  PARAMETER["Central_Meridian",-118],
+  PARAMETER["Standard_Parallel_1",34.03333333333333],
+  PARAMETER["Standard_Parallel_2",35.46666666666667],
+  PARAMETER["Latitude_Of_Origin",33.5],
+  UNIT["Foot_US",0.30480060960121924],
+  AUTHORITY["EPSG","102645"]]`
+  const SR = normalizeSR(wkt)
+  t.equal(SR.wkt, wkt)
 })
 
 test('normalize SR with a EPSG:3857 string', t => {
   t.plan(1)
-  const spatialReference = 'EPSG:3857'
-  const SR = normalizeSR(spatialReference)
+  const SR = normalizeSR('EPSG:3857')
   t.equal(SR.wkid, 3857)
 })
 
 test('normalize SR with a 3857 number', t => {
   t.plan(1)
-  const spatialReference = 3857
-  const SR = normalizeSR(spatialReference)
+  const SR = normalizeSR(3857)
   t.equal(SR.wkid, 3857)
 })
 
 test('normalize SR with a 102100 number', t => {
   t.plan(1)
-  const spatialReference = 102100
-  const SR = normalizeSR(spatialReference)
+  const SR = normalizeSR(102100)
   t.equal(SR.wkid, 3857)
 })
 
-// test('normalize input SR with geometry.wkt string', t => {
-//   t.plan(1)
-//   const options = {
-//     geometry: {
-//       xmin: 0,
-//       ymin: 0,
-//       xmax: 1,
-//       ymax: 1,
-//       spatialReference: {
-//         wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
-//       }
-//     }
-//   }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:3857')
-// })
+test('normalize SR with a State Plane wkt', t => {
+  t.plan(1)
+  const wkt = `PROJCS["NAD_1983_StatePlane_California_V_FIPS_0405_Feet",
+  GEOGCS["GCS_North_American_1983",
+      DATUM["North_American_Datum_1983",
+          SPHEROID["GRS_1980",6378137,298.257222101]],
+      PRIMEM["Greenwich",0],
+      UNIT["Degree",0.017453292519943295]],
+  PROJECTION["Lambert_Conformal_Conic_2SP"],
+  PARAMETER["False_Easting",6561666.666666666],
+  PARAMETER["False_Northing",1640416.666666667],
+  PARAMETER["Central_Meridian",-118],
+  PARAMETER["Standard_Parallel_1",34.03333333333333],
+  PARAMETER["Standard_Parallel_2",35.46666666666667],
+  PARAMETER["Latitude_Of_Origin",33.5],
+  UNIT["Foot_US",0.30480060960121924],
+  AUTHORITY["EPSG","102645"]]`
+  const SR = normalizeSR({ wkt })
+  t.equal(SR.wkt, wkt)
+})
 
-// test('normalize input SR with geometry.latestWkid', t => {
-//   t.plan(1)
-//   const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { latestWkid: 4269 } } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4269')
-// })
+test('normalize input SR with geometry.wkt string', t => {
+  t.plan(1)
+  const options = {
+    geometry: {
+      spatialReference: {
+        wkt: 'PROJCS["WGS_1984_Web_Mercator_Auxiliary_Sphere",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Mercator_Auxiliary_Sphere"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-6.828007551173374],PARAMETER["Standard_Parallel_1",0.0],PARAMETER["Auxiliary_Sphere_Type",0.0],UNIT["Meter",1.0]]'
+      }
+    }
+  }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:3857`)
+})
 
-// test('normalize input SR with geometry.wkid', t => {
-//   t.plan(1)
-//   const options = { geometry: { xmin: 0, ymin: 0, xmax: 1, ymax: 1, spatialReference: { wkid: 4269 } } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4269')
-// })
+test('normalize input SR with geometry.latestWkid', t => {
+  t.plan(1)
+  const options = { geometry: { spatialReference: { latestWkid: 4269 } } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:4269`)
+})
 
-// test('normalize input SR with inSR EPSG string', t => {
-//   t.plan(1)
-//   const options = { inSR: 'EPSG:4269' }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4269')
-// })
+test('normalize input SR with geometry.wkid', t => {
+  t.plan(1)
+  const options = { geometry: { spatialReference: { wkid: 4269 } } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:4269`)
+})
 
-// test('normalize input SR with inSR string', t => {
-//   t.plan(1)
-//   const options = { inSR: '4269' }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4269')
-// })
+test('normalize input SR with inSR string', t => {
+  t.plan(1)
+  const options = { inSR: '4269' }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:4269`)
+})
 
-// test('normalize input SR with inSR integer', t => {
-//   t.plan(1)
-//   const options = { inSR: 4269 }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4269')
-// })
+test('normalize input SR with undefined inSR', t => {
+  t.plan(1)
+  const options = { }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:4326`)
+})
 
-// test('normalize input SR with undefined inSR', t => {
-//   t.plan(1)
-//   const options = { }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4326')
-// })
+test('normalize input SR with inSR={ }', t => {
+  t.plan(1)
+  const options = { inSR: { } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:4326`)
+})
 
-// test('normalize input SR with inSR=102100', t => {
-//   t.plan(1)
-//   const options = { inSR: 102100 }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:3857')
-// })
+test('normalize input SR with  bogus inSR={wkid:9999}, default to 4326', t => {
+  t.plan(1)
+  const options = { inSR: { wkid: 9999 } }
+  const inSR = normalizeInSR(options)
+  t.equal(inSR, `EPSG:4326`)
+})
 
-// test('normalize input SR with inSR={wkid: 102100}', t => {
-//   t.plan(1)
-//   const options = { inSR: { wkid: 102100 } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:3857')
-// })
+test('normalize source data SR with sourceDataSR string', t => {
+  t.plan(1)
+  const sourceSR = normalizeSourceDataSR('4269')
+  t.equal(sourceSR, `EPSG:4269`)
+})
 
-// test('normalize input SR with inSR={latestWkid: 102100}', t => {
-//   t.plan(1)
-//   const options = { inSR: { latestWkid: 102100 } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:3857')
-// })
+test('normalize source data SR with undefined sourceDataSR', t => {
+  t.plan(1)
+  const options = { }
+  const sourceSR = normalizeInSR(options)
+  t.equal(sourceSR, `EPSG:4326`)
+})
 
-// test('normalize input SR with inSR={wkid: 4629}', t => {
-//   t.plan(1)
-//   const options = { inSR: { wkid: 4629 } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4629')
-// })
+test('normalize source data SR with sourceDataSR={ }', t => {
+  t.plan(1)
+  const options = { inSR: { } }
+  const sourceSR = normalizeInSR(options)
+  t.equal(sourceSR, `EPSG:4326`)
+})
 
-// test('normalize input SR with inSR={ }', t => {
-//   t.plan(1)
-//   const options = { inSR: { } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4326')
-// })
-
-// test('normalize input SR with  bogus inSR={wkid:9999}, default to 4326', t => {
-//   t.plan(1)
-//   const options = { inSR: { wkid: 9999 } }
-//   const inSR = normalizeInSR(options)
-//   t.equal(inSR, 'EPSG:4326')
-// })
+test('normalize source data SR with unknown wkid, default to 4326', t => {
+  t.plan(1)
+  const options = { inSR: { wkid: 9999 } }
+  const sourceSR = normalizeInSR(options)
+  t.equal(sourceSR, `EPSG:4326`)
+})

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -1,5 +1,21 @@
 const test = require('tape')
 const Winnow = require('../src')
+const trees = require('./fixtures/street-trees-102645.json')
+const caStatePlaneWKT = `PROJCS["NAD_1983_StatePlane_California_V_FIPS_0405_Feet",
+GEOGCS["GCS_North_American_1983",
+    DATUM["North_American_Datum_1983",
+        SPHEROID["GRS_1980",6378137,298.257222101]],
+    PRIMEM["Greenwich",0],
+    UNIT["Degree",0.017453292519943295]],
+PROJECTION["Lambert_Conformal_Conic_2SP"],
+PARAMETER["False_Easting",6561666.666666666],
+PARAMETER["False_Northing",1640416.666666667],
+PARAMETER["Central_Meridian",-118],
+PARAMETER["Standard_Parallel_1",34.03333333333333],
+PARAMETER["Standard_Parallel_2",35.46666666666667],
+PARAMETER["Latitude_Of_Origin",33.5],
+UNIT["Foot_US",0.30480060960121924],
+AUTHORITY["EPSG","102645"]]`
 
 test('compiling a complex query', t => {
   try {
@@ -29,4 +45,67 @@ test('compiling with several and statements', t => {
     t.fail(e)
     t.end()
   }
+})
+
+test('prepare query with projection, sourceProjection, and geometry, then execute filter on non-4326 source data', (t) => {
+  t.plan(3)
+  const options = {
+    geometry: {
+      xmin: -118.15738230943678,
+      ymin: 34.179713563470166,
+      xmax: -118.15718114376067,
+      ymax: 34.18019950919287,
+      spatialReference: {
+        wkid: 4326
+      }
+    },
+    sourceDataSR: caStatePlaneWKT
+  }
+  const query = Winnow.prepareQuery(options)
+  const filtered = query(trees)
+  t.equal(filtered.features.length, 3)
+  t.equal(filtered.features[0].geometry.coordinates[0], 6514083.848741564)
+  t.equal(filtered.features[0].geometry.coordinates[1], 1887939.4934484742)
+})
+
+test('prepare query with projection, sourceProjection, and geometry, then execute filter on non-4326 source data', (t) => {
+  t.plan(3)
+  const options = {
+    geometry: {
+      xmin: -118.15738230943678,
+      ymin: 34.179713563470166,
+      xmax: -118.15718114376067,
+      ymax: 34.18019950919287,
+      spatialReference: {
+        wkid: 4326
+      }
+    },
+    sourceDataSR: caStatePlaneWKT
+  }
+  const query = Winnow.prepareQuery(options)
+  const filtered = query(trees)
+  t.equal(filtered.features.length, 3)
+  t.equal(filtered.features[0].geometry.coordinates[0], 6514083.848741564)
+  t.equal(filtered.features[0].geometry.coordinates[1], 1887939.4934484742)
+})
+
+test('query with projection, sourceProjection, and geometry, then execute filter on non-4326 source data', (t) => {
+  t.plan(3)
+  const options = {
+    geometry: {
+      xmin: -118.15738230943678,
+      ymin: 34.179713563470166,
+      xmax: -118.15718114376067,
+      ymax: 34.18019950919287,
+      spatialReference: {
+        wkid: 4326
+      }
+    },
+    sourceDataSR: caStatePlaneWKT
+  }
+
+  const filtered = Winnow.query(trees, options)
+  t.equal(filtered.features.length, 3)
+  t.equal(filtered.features[0].geometry.coordinates[0], 6514083.848741564)
+  t.equal(filtered.features[0].geometry.coordinates[1], 1887939.4934484742)
 })

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -59,7 +59,7 @@ test('prepare query with projection, sourceProjection, and geometry, then execut
         wkid: 4326
       }
     },
-    sourceDataSR: caStatePlaneWKT
+    sourceSR: caStatePlaneWKT
   }
   const query = Winnow.prepareQuery(options)
   const filtered = query(trees)
@@ -80,7 +80,7 @@ test('prepare query with projection, sourceProjection, and geometry, then execut
         wkt: caStatePlaneWKT
       }
     },
-    sourceDataSR: caStatePlaneWKT
+    sourceSR: caStatePlaneWKT
   }
   const query = Winnow.prepareQuery(options)
   const filtered = query(trees)
@@ -101,7 +101,7 @@ test('query with projection, sourceProjection, and geometry, then execute filter
         wkid: 4326
       }
     },
-    sourceDataSR: caStatePlaneWKT
+    sourceSR: caStatePlaneWKT
   }
 
   const filtered = Winnow.query(trees, options)

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -68,16 +68,16 @@ test('prepare query with projection, sourceProjection, and geometry, then execut
   t.equal(filtered.features[0].geometry.coordinates[1], 1887939.4934484742)
 })
 
-test('prepare query with projection, sourceProjection, and geometry, then execute filter on non-4326 source data', (t) => {
+test('prepare query with projection, sourceProjection, and geometry, then execute non-4326 filter on non-4326 source data', (t) => {
   t.plan(3)
   const options = {
     geometry: {
-      xmin: -118.15738230943678,
-      ymin: 34.179713563470166,
-      xmax: -118.15718114376067,
-      ymax: 34.18019950919287,
+      xmin: 6514066.3001615712419152,
+      ymin: 1887820.5006760144606233,
+      xmax: 6514127.4193187793716788,
+      ymax: 1887997.4401315276045352,
       spatialReference: {
-        wkid: 4326
+        wkid: caStatePlaneWKT
       }
     },
     sourceDataSR: caStatePlaneWKT

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -77,7 +77,7 @@ test('prepare query with projection, sourceProjection, and geometry, then execut
       xmax: 6514127.4193187793716788,
       ymax: 1887997.4401315276045352,
       spatialReference: {
-        wkid: caStatePlaneWKT
+        wkt: caStatePlaneWKT
       }
     },
     sourceDataSR: caStatePlaneWKT

--- a/test/project-coordinates.js
+++ b/test/project-coordinates.js
@@ -28,3 +28,10 @@ test('Project coordinates correctly', t => {
   t.equal(transformed[0], 0, 'projected correctly')
   t.equal(transformed[1], 9100250.907059547, 'projected correctly')
 })
+
+test('Do not project coordinates if target and source spatial reference are the same', t => {
+  t.plan(2)
+  const transformed = projectCoordinates([0, 63], {sourceSR: `EPSG:4326`, targetSR: `EPSG:4326`})
+  t.equal(transformed[0], 0, 'projected correctly')
+  t.equal(transformed[1], 63, 'projected correctly')
+})

--- a/test/project-coordinates.js
+++ b/test/project-coordinates.js
@@ -31,7 +31,7 @@ test('Project coordinates correctly', t => {
 
 test('Do not project coordinates if target and source spatial reference are the same', t => {
   t.plan(2)
-  const transformed = projectCoordinates([0, 63], {sourceSR: `EPSG:4326`, targetSR: `EPSG:4326`})
+  const transformed = projectCoordinates([0, 63], {fromSR: `EPSG:4326`, toSR: `EPSG:4326`})
   t.equal(transformed[0], 0, 'projected correctly')
   t.equal(transformed[1], 63, 'projected correctly')
 })


### PR DESCRIPTION
This PR enables filtering by geometry on data that is not necessarily in SRS WGS84 (prior to this modification, source data was assumed to be WGS84).  I have added a new option named `sourceDataSR` which informs winnow that source data that is in a non-WGS84 SRS.  Using this SRS, the geometry envelop can be projected correctly so that in matches the source data.

Unless the source data SRS is one of handful of SRSs that proj4 stores in its hash, the SRS must be passed along to proj4 as WKT.  Thus the PR includes some refactoring on functions that normalize incoming SRSs.

Added tests.