### PR TITLE
Move esriFy, ordering, limit, and offset functionality to ala-sql.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Moved `esriFy` function to SQL, which now allows ORDER BY, LIMIT, OFFSET to also be applied via SQL.
+
 ## [1.16.0] - 06-29-2018
 ### Added
 * Add normalization of a `option.sourceSR`; this option identifies the CRS of the source data and defaults to 'EPSG:4326'; 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
+* Ensure OBJECTID is omitted from query results when options specifically exclude it (e.g., `returnIdsOnly=true`)
 * Moved `esriFy` function to SQL, which now allows ORDER BY, LIMIT, OFFSET to also be applied via SQL.
 
 ## [1.16.0] - 06-29-2018

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -24,23 +24,17 @@ function aggregateQuery (features, query, options) {
   return finishQuery(filtered, options)
 }
 
-function limitQuery (features, query, options) {
-  const params = Query.params(features, options)
-  const filtered = sql(query, params)
-
-  const limitExceeded = (filtered.length === options.limit && features.length > options.limit) || false
-  if (options.collection) {
-    options.collection.metadata = Object.assign({}, options.collection.metadata, { limitExceeded })
-  }
-  return finishQuery(filtered, options)
-}
-
 function standardQuery (features, query, options) {
   const params = Query.params(features, options)
-  const filtered = sql(query, params)
+  let filtered = sql(query, params)
 
+  // Handling for limit queries
   if (options.collection && options.limit) {
-    const limitExceeded = (filtered.length === options.limit && features.length > options.limit) || false
+    let limitExceeded = false
+    if (filtered.length === options.limit) {
+      limitExceeded = true
+      filtered = filtered.slice(0, -1)
+    }
     options.collection.metadata = Object.assign({}, options.collection.metadata, { limitExceeded })
   }
   return finishQuery(filtered, options)
@@ -60,4 +54,4 @@ function finishQuery (features, options) {
   }
 }
 
-module.exports = { breaksQuery, aggregateQuery, limitQuery, standardQuery, finishQuery }
+module.exports = { breaksQuery, aggregateQuery, standardQuery, finishQuery }

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -29,13 +29,13 @@ function standardQuery (features, query, options) {
   let filtered = sql(query, params)
 
   // Handling for limit queries
-  if (options.collection && options.limit) {
+  if (options.limit) {
     let limitExceeded = false
     if (filtered.length === options.limit) {
       limitExceeded = true
       filtered = filtered.slice(0, -1)
     }
-    options.collection.metadata = Object.assign({}, options.collection.metadata, { limitExceeded })
+    if (options.collection) options.collection.metadata = Object.assign({}, options.collection.metadata, { limitExceeded })
   }
   return finishQuery(filtered, options)
 }

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -1,9 +1,7 @@
 'use strict'
-const farmhash = require('farmhash')
 const sql = require('./sql')
 const Query = require('./query')
 const { calculateClassBreaks, calculateUniqueValueBreaks } = require('./generateBreaks/index')
-const _ = require('lodash')
 
 function breaksQuery (features, query, options) {
   const queriedData = standardQuery(features, query, options)
@@ -27,77 +25,28 @@ function aggregateQuery (features, query, options) {
 }
 
 function limitQuery (features, query, options) {
-  let filtered = []
-  let limitExceeded = false
-  if (options.offset) {
-    if (options.offset >= features.length) throw new Error('OFFSET >= features length: ' + options)
-    options.limit += options.offset
-  }
-  features.some((feature) => {
-    const result = processQuery(feature, query, options)
-    if (result) filtered.push(result)
-    if (filtered.length === (options.limit + 1)) {
-      limitExceeded = true
-      return true
-    }
-  })
+  const params = Query.params(features, options)
+  const filtered = sql(query, params)
 
-  if (limitExceeded) filtered = filtered.slice(0, -1)
-
+  const limitExceeded = (filtered.length === options.limit && features.length > options.limit) || false
   if (options.collection) {
     options.collection.metadata = Object.assign({}, options.collection.metadata, { limitExceeded })
   }
-
   return finishQuery(filtered, options)
 }
 
 function standardQuery (features, query, options) {
-  const filtered = features.reduce((filteredFeatures, feature) => {
-    const result = processQuery(feature, query, options)
-    if (result) filteredFeatures.push(result)
-    return filteredFeatures
-  }, [])
+  const params = Query.params(features, options)
+  const filtered = sql(query, params)
+
+  if (options.collection && options.limit) {
+    const limitExceeded = (filtered.length === options.limit && features.length > options.limit) || false
+    options.collection.metadata = Object.assign({}, options.collection.metadata, { limitExceeded })
+  }
   return finishQuery(filtered, options)
 }
 
-function processQuery (feature, query, options) {
-  const params = Query.params([feature], options)
-  const result = sql(query, params)[0]
-
-  if (result && options.toEsri) return esriFy(result, feature, options)
-  else return result
-}
-
-function esriFy (result, feature, options) {
-  if (options.dateFields.length) {
-    // mutating dates has down stream consequences if the data is reused
-    result.attributes = _.cloneDeep(result.attributes)
-    options.dateFields.forEach(field => {
-      result.attributes[field] = new Date(result.attributes[field]).getTime()
-    })
-  }
-
-  const idField = _.get(options, 'collection.metadata.idField')
-
-  // If the idField for the model set use its value as OBJECTID
-  if (idField) {
-    if (!Number.isInteger(feature.properties[idField]) || feature.properties[idField] > 2147483647) {
-      console.warn(`WARNING: OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)
-    }
-    result.attributes.OBJECTID = feature.properties[idField]
-  } else {
-    // Create an OBJECTID by creating a numeric hash from the stringified feature
-    // Note possibility of OBJECTID collisions with this method still exists, but should be small
-    result.attributes.OBJECTID = createIntHash(JSON.stringify(feature))
-  }
-  return result
-}
-
 function finishQuery (features, options) {
-  if (options.offset) {
-    if (options.offset >= features.length) throw new Error('OFFSET >= features length: ' + options)
-    features = features.slice(options.offset)
-  }
   if (options.groupBy) {
     return features
   } else if (options.aggregates) {
@@ -109,17 +58,6 @@ function finishQuery (features, options) {
   } else {
     return features
   }
-}
-
-/**
- * Create integer hash in range of 0 - 2147483647 from string
- * @param {*} inputStr - any string
- */
-function createIntHash (inputStr) {
-  // Hash to 32 bit unsigned integer
-  const hash = farmhash.hash32(inputStr)
-  // Normalize to range of postive values of signed integer
-  return Math.round((hash / 4294967295) * (2147483647))
 }
 
 module.exports = { breaksQuery, aggregateQuery, limitQuery, standardQuery, finishQuery }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const sql = require('./sql')
 const Query = require('./query')
 const Params = require('./params')
 const Options = require('./options')
-const { breaksQuery, aggregateQuery, limitQuery, standardQuery, finishQuery } = require('./executeQuery')
+const { breaksQuery, aggregateQuery, standardQuery, finishQuery } = require('./executeQuery')
 const _ = require('lodash')
 const Winnow = {}
 
@@ -24,7 +24,6 @@ Winnow.query = function (input, options = {}) {
 
   if (options.classification) return breaksQuery(features, query, options)
   if (options.aggregates) return aggregateQuery(features, query, options)
-  else if (options.limit) return limitQuery(features, query, options)
   else return standardQuery(features, query, options)
 }
 

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -13,6 +13,7 @@ const {
   normalizeGeometry,
   normalizeOffset,
   normalizeProjection
+
 } = require('./normalizeOptions')
 const { normalizeClassification } = require('./normalizeClassification')
 
@@ -27,12 +28,14 @@ function prepare (options, features) {
     aggregates: normalizeAggregates(options),
     groupBy: normalizeGroupBy(options),
     limit: normalizeLimit(options),
-    offset: normalizeOffset(options),
     projection: normalizeProjection(options),
     classification: normalizeClassification(options)
   })
+  prepared.offset = normalizeOffset(options)
   prepared.dateFields = normalizeDateFields(prepared.collection, prepared.fields)
+  prepared.idField = _.get(prepared.collection, 'metadata.idField') || null
   if (prepared.where === '1=1') delete prepared.where
+
   return prepared
 }
 

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -147,7 +147,9 @@ function normalizeSR (input) {
  * @returns {integer} or undefined
  */
 function normalizeLimit (options) {
-  return options.limit || options.resultRecordCount || options.count || options.maxFeatures
+  const limit = options.limit || options.resultRecordCount || options.count || options.maxFeatures
+  // If there is a limit, add 1 to it so we can later calculate a limitExceeded. The result set will be resized accordingly, post SQL
+  if (limit) return limit + 1
 }
 
 /**

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -141,12 +141,23 @@ function normalizeSR (input) {
   }
 }
 
+/**
+ * Normalize the limit option; defaults to undefined
+ * @param {object} options
+ * @returns {integer} or undefined
+ */
 function normalizeLimit (options) {
   return options.limit || options.resultRecordCount || options.count || options.maxFeatures
 }
 
+/**
+ * Normalize the offset option. If no limit is defined, then return offset as undefined. ala-sql
+ * requires OFFSET to be paired with a LIMIT
+ * @param {object} options
+ * @returns {integer} or undefined
+ */
 function normalizeOffset (options) {
-  return options.offset || options.resultOffset
+  return (options.limit) ? (options.offset || options.resultOffset) : undefined
 }
 
 function normalizeProjection (options) {

--- a/src/options/normalizeSQL.js
+++ b/src/options/normalizeSQL.js
@@ -19,6 +19,7 @@ function normalizeDate (where) {
 function normalizeFields (options) {
   const fields = options.fields || options.outFields
   if (fields === '*') return undefined
+  if (options.returnIdsOnly === true) return ['OBJECTID']
   if (typeof fields === 'string' || fields instanceof String) return fields.split(',')
   if (fields instanceof Array) return fields
   return undefined

--- a/src/query.js
+++ b/src/query.js
@@ -15,7 +15,7 @@ function create (options) {
   if (options.geometry && where) query += ` AND ${geomFilter}`
   if (options.order || options.orderByFields) query += order
   if (options.limit) query += ` LIMIT ${options.limit}`
-  // if (options.offset) query += ` OFFSET ${options.offset}` // handled in executeQuery.js
+  if (options.offset) query += ` OFFSET ${options.offset}` // handled in executeQuery.js
   return query
 }
 

--- a/src/select/fields.js
+++ b/src/select/fields.js
@@ -9,6 +9,7 @@ function createClause (options = {}, idField = null) {
 
   // Comma-delimited list of date-fields is needed for formatting ESRI specific output
   let dateFields = options.dateFields.join(',')
+  let requiresObjectId = !!options.returnIdsOnly || !(options.fields instanceof Array && !options.fields.includes('OBJECTID'))
 
   // If options.fields defined, selected only a subset of teh GeoJSON properties
   if (options.fields) {
@@ -16,10 +17,10 @@ function createClause (options = {}, idField = null) {
     let fields = (options.fields instanceof Array) ? options.fields.join(',') : options.fields.replace(/,\s+/g, ',')
 
     // For ESRI specific output, process w/ "pickAndEsriFy"; for simple GeoJSON output, process with "pick"
-    clause = (options.toEsri) ? `pickAndEsriFy(properties, geometry, "${fields}", "${dateFields}", "${options.idField}") as attributes` : `pick(properties, "${fields}") as properties`
+    clause = (options.toEsri) ? `pickAndEsriFy(properties, geometry, "${fields}", "${dateFields}", "${requiresObjectId}", "${options.idField}") as attributes` : `pick(properties, "${fields}") as properties`
   } else if (options.toEsri) {
     // For ESRI specific output, process w/ "esriFy"
-    clause = `esriFy(properties, geometry, "${dateFields}", "${options.idField}") as attributes`
+    clause = `esriFy(properties, geometry, "${dateFields}", "${requiresObjectId}", "${options.idField}") as attributes`
   }
   return clause
 }

--- a/src/select/fields.js
+++ b/src/select/fields.js
@@ -1,14 +1,27 @@
-function createClause (options = {}) {
-  const propType = options.toEsri ? 'attributes' : 'properties'
+/**
+ * Create the SQL fragment used to SELECT GeoJSON attributes
+ * @param {object} options
+ * @param {string} idField a string that identifies which property can be used as the OBJECTID
+ */
+function createClause (options = {}, idField = null) {
+  // Default clause
+  let clause = `type, properties as properties`
 
+  // Comma-delimited list of date-fields is needed for formatting ESRI specific output
+  let dateFields = options.dateFields.join(',')
+
+  // If options.fields defined, selected only a subset of teh GeoJSON properties
   if (options.fields) {
-    let fields
-    if (typeof options.fields !== 'string') fields = options.fields.join(',')
-    else fields = options.fields.replace(/,\s+/g, ',')
-    if (options.toEsri) { return `pick(properties, "${fields}") as ${propType}` } else { return `type, pick(properties, "${fields}") as ${propType}` }
-  } else {
-    if (options.toEsri) { return `properties as ${propType}` } else { return `type, properties as ${propType}` }
+    // if option.fields is an Array, join with comma; if already a comma delimited list, remove any spaces
+    let fields = (options.fields instanceof Array) ? options.fields.join(',') : options.fields.replace(/,\s+/g, ',')
+
+    // For ESRI specific output, process w/ "pickAndEsriFy"; for simple GeoJSON output, process with "pick"
+    clause = (options.toEsri) ? `pickAndEsriFy(properties, geometry, "${fields}", "${dateFields}", "${options.idField}") as attributes` : `pick(properties, "${fields}") as properties`
+  } else if (options.toEsri) {
+    // For ESRI specific output, process w/ "esriFy"
+    clause = `esriFy(properties, geometry, "${dateFields}", "${options.idField}") as attributes`
   }
+  return clause
 }
 
 module.exports = { createClause }

--- a/src/sql.js
+++ b/src/sql.js
@@ -1,4 +1,5 @@
 const Terraformer = require('terraformer')
+const farmhash = require('farmhash')
 const transformArray = require('./geometry/transform-array')
 const convertToEsri = require('./geometry/convert-to-esri')
 const convertFromEsri = require('./geometry/convert-from-esri')
@@ -55,9 +56,18 @@ sql.fn.geohash = function (geometry = {}, precision) {
 }
 
 sql.fn.pick = function (properties, fields) {
-  fields = fields.split(',')
-  return _.pick(properties, fields)
+  const parsedFields = fields.split(',')
+  return _.pick(properties, parsedFields)
 }
+
+sql.fn.pickAndEsriFy = function (properties, geometry, fields, dateFields, idField) {
+  const parsedFields = fields.split(',')
+  const selectedProperties = _.pick(properties, parsedFields)
+  const esriProperties = esriFy(selectedProperties, geometry, dateFields, idField)
+  return esriProperties
+}
+
+sql.fn.esriFy = esriFy
 
 sql.fn.esriGeom = function (geometry) {
   if (geometry && geometry.type) {
@@ -92,4 +102,38 @@ sql.aggr.hash = function (value, obj, acc) {
   return obj
 }
 
+function esriFy (properties, geometry, dateFields, idField) {
+  const parsedDateFields = dateFields.split(',')
+  if (parsedDateFields.length) {
+    parsedDateFields.forEach(field => {
+      properties[field] = new Date(properties[field]).getTime()
+    })
+  }
+
+  idField = (idField === 'null') ? null : idField
+
+  // If the idField for the model set use its value as OBJECTID
+  if (idField) {
+    if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test' && (!Number.isInteger(properties[idField]) || properties[idField] > 2147483647)) {
+      console.warn(`WARNING: OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)
+    }
+    properties.OBJECTID = properties[idField]
+  } else {
+    // Create an OBJECTID by creating a numeric hash from the stringified feature
+    // Note possibility of OBJECTID collisions with this method still exists, but should be small
+    properties.OBJECTID = createIntHash(JSON.stringify({properties, geometry}))
+  }
+  return properties
+}
+
+/**
+ * Create integer hash in range of 0 - 2147483647 from string
+ * @param {*} inputStr - any string
+ */
+function createIntHash (inputStr) {
+  // Hash to 32 bit unsigned integer
+  const hash = farmhash.hash32(inputStr)
+  // Normalize to range of postive values of signed integer
+  return Math.round((hash / 4294967295) * (2147483647))
+}
 module.exports = sql

--- a/src/sql.js
+++ b/src/sql.js
@@ -70,9 +70,8 @@ sql.fn.pick = function (properties, fields) {
  */
 sql.fn.pickAndEsriFy = function (properties, geometry, fields, dateFields, requiresObjectId, idField) {
   const parsedFields = fields.split(',')
-  const selectedProperties = _.pick(properties, parsedFields)
-  const esriProperties = esriFy(selectedProperties, geometry, dateFields, requiresObjectId, idField)
-  return esriProperties
+  const esriProperties = esriFy(properties, geometry, dateFields, requiresObjectId, idField)
+  return _.pick(esriProperties, parsedFields)
 }
 
 sql.fn.esriFy = esriFy

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,4 +1,5 @@
 'use strict'
+const _ = require('lodash')
 const test = require('tape')
 const winnow = require('../src')
 
@@ -350,67 +351,6 @@ test('With a where and a geometry option', t => {
   run('trees', options, 2315, t)
 })
 
-test('With a limit option', t => {
-  t.plan(3)
-  const data = 'trees'
-  const options = {
-    limit: 10
-  }
-  const features = require(`./fixtures/${data}.json`).features
-  const filtered = winnow.query(features, options)
-  t.equal(filtered.length, 10)
-  t.equal(filtered[0].properties.Common_Name, 'SOUTHERN MAGNOLIA')
-  t.equal(filtered[9].properties.Common_Name, 'WINDMILL PALM')
-})
-
-test('With an offset option', t => {
-  t.plan(3)
-  const data = 'trees'
-  const options = {
-    offset: 10
-  }
-  const features = require(`./fixtures/${data}.json`).features
-  const filtered = winnow.query(features, options)
-  t.equal(filtered.length, 71122)
-  t.equal(filtered[0].properties.Common_Name, 'SOUTHERN MAGNOLIA')
-  t.equal(filtered[9].properties.Common_Name, 'JACARANDA')
-})
-
-test('With a limit and an offset option', t => {
-  t.plan(3)
-  const data = 'trees'
-  const options = {
-    limit: 10,
-    offset: 11
-  }
-  const features = require(`./fixtures/${data}.json`).features
-  const filtered = winnow.query(features, options)
-  t.equal(filtered.length, 10)
-  t.equal(filtered[0].properties.Common_Name, 'JACARANDA')
-  t.equal(filtered[9].properties.Common_Name, 'LIVE OAK')
-})
-
-test('With an offset larger than returned features', t => {
-  t.plan(1)
-  const data = 'trees'
-  const options = {
-    offset: 100000
-  }
-  const features = require(`./fixtures/${data}.json`).features
-  t.throws(function () { winnow.query(features, options) })
-})
-
-test('With a limit and an offset larger than returned features', t => {
-  t.plan(1)
-  const data = 'trees'
-  const options = {
-    limit: 10,
-    offset: 100000
-  }
-  const features = require(`./fixtures/${data}.json`).features
-  t.throws(function () { winnow.query(features, options) })
-})
-
 test('With a where, geometry, limit and offset option', t => {
   t.plan(5)
   const data = 'trees'
@@ -585,7 +525,8 @@ test('with a between query', t => {
 
 function run (data, options, expected, t) {
   t.plan(1)
-  const features = require(`./fixtures/${data}.json`).features
+  const fixtures = _.cloneDeep(require(`./fixtures/${data}.json`))
+  const features = fixtures.features
   const filtered = winnow.query(features, options)
   t.equal(filtered.length, expected)
 }

--- a/test/limit.js
+++ b/test/limit.js
@@ -1,0 +1,46 @@
+'use strict'
+const test = require('tape')
+const winnow = require('../src')
+const fixture = require(`./fixtures/trees.json`)
+
+test('With a limit option', t => {
+  t.plan(3)
+  const options = {
+    limit: 10
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equal(filtered.length, 10)
+  t.equal(filtered[0].properties.Common_Name, 'SOUTHERN MAGNOLIA')
+  t.equal(filtered[9].properties.Common_Name, 'WINDMILL PALM')
+})
+
+test('With a limit and an offset option', t => {
+  t.plan(3)
+  const options = {
+    limit: 10,
+    offset: 11
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equal(filtered.length, 10)
+  t.equal(filtered[0].properties.Common_Name, 'JACARANDA')
+  t.equal(filtered[9].properties.Common_Name, 'LIVE OAK')
+})
+
+test('With an offset option, but no limit; should return all features', t => {
+  t.plan(1)
+  const options = {
+    offset: 10
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equal(filtered.length, 71132)
+})
+
+test('With a limit and an offset larger than returned features, should return no features', t => {
+  t.plan(1)
+  const options = {
+    limit: 10,
+    offset: 100000
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equal(filtered.length, 0)
+})

--- a/test/order.js
+++ b/test/order.js
@@ -1,0 +1,69 @@
+'use strict'
+const test = require('tape')
+const _ = require('lodash')
+const winnow = require('../src')
+const fixture = require(`./fixtures/trees.json`)
+
+test('With a limit of 10, order by OBJECTID ASC', t => {
+  t.plan(2)
+  const options = {
+    limit: 10,
+    order: 'OBJECTID ASC'
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equals(filtered[0].properties.OBJECTID, 1)
+  t.equals(filtered[1].properties.OBJECTID, 2)
+})
+
+test('With a limit of 10, toEsri, and an idField, order by OBJECTID ASC', t => {
+  t.plan(2)
+  const options = {
+    limit: 10,
+    order: 'OBJECTID',
+    toEsri: true,
+    collection: { metadata: { idField: 'OBJECTID' } }
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equals(filtered.features[0].attributes.OBJECTID, 1)
+  t.equals(filtered.features[1].attributes.OBJECTID, 2)
+})
+
+test('With a limit of 10, toEsri, and an idField, order by OBJECTID DESC', t => {
+  t.plan(2)
+  const options = {
+    limit: 10,
+    order: 'OBJECTID DESC',
+    toEsri: true,
+    collection: { metadata: { idField: 'OBJECTID' } }
+  }
+  const filtered = winnow.query(fixture.features, options)
+  t.equals(filtered.features[0].attributes.OBJECTID, 82335)
+  t.equals(filtered.features[1].attributes.OBJECTID, 82334)
+})
+
+test('With a limit of 10, toEsri and no idField specified (winnow generates OBJECTID), order by OBJECTID DESC', t => {
+  t.plan(3)
+  const options = {
+    limit: 10,
+    order: 'OBJECTID DESC',
+    toEsri: true
+  }
+  // Clone fixture so it isn't mutated
+  const filtered = winnow.query(_.cloneDeep(fixture).features, options)
+  t.ok(filtered[0].attributes.OBJECTID > filtered[1].attributes.OBJECTID)
+  t.ok(filtered[1].attributes.OBJECTID > filtered[2].attributes.OBJECTID)
+  t.ok(filtered[2].attributes.OBJECTID > filtered[3].attributes.OBJECTID)
+})
+
+test('With a limit of 10 and toEsri and no idField specified, order by Species DESC', t => {
+  t.plan(2)
+  const options = {
+    limit: 10,
+    order: 'Species DESC',
+    toEsri: true
+  }
+  const features = require(`./fixtures/trees.json`).features
+  const filtered = winnow.query(features, options)
+  t.equal(filtered[0].attributes.Species, 'ugandense')
+  t.equal(filtered[1].attributes.Species, 'sinensis')
+})

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -86,6 +86,7 @@ test('use idField not name OBJECTID', t => {
   }
   const result = Winnow.query(fixture, options)
   t.equal(result.features[0].attributes.hasOwnProperty('OBJECTID'), true)
+  t.equal(result.features[0].attributes.OBJECTID, 11303)
   t.equal(result.metadata.idField, 'featureId')
   t.end()
 })
@@ -191,8 +192,7 @@ test('do not exclude objectid when returnIdsOnly = true', t => {
   }
   const fixture = _.cloneDeep(geojson)
   const result = Winnow.query(fixture, options)
-  t.equal(Object.keys(result.features[0].attributes).length, 2)
-  t.equal(result.features[0].attributes.hasOwnProperty('string'), true)
+  t.equal(Object.keys(result.features[0].attributes).length, 1)
   t.equal(result.features[0].attributes.hasOwnProperty('OBJECTID'), true)
   t.end()
 })

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -143,7 +143,7 @@ test('converting date with passed in fields metadata', t => {
   const options = {
     toEsri: true
   }
-  const fixture = Object.assign({}, geojson, {
+  const fixture = Object.assign({}, _.cloneDeep(geojson), {
     metdata: {
       fields: [
         {
@@ -168,5 +168,31 @@ test('converting date with passed in fields metadata', t => {
   const result = Winnow.query(fixture, options)
   t.equal(result.features[0].attributes.date, 1331769600000)
   t.equal(Object.keys(result.metadata.fields).length, 4)
+  t.end()
+})
+
+test('exclude objectid addition when not part of outfields', t => {
+  const options = {
+    toEsri: true,
+    outFields: ['string']
+  }
+  const fixture = _.cloneDeep(geojson)
+  const result = Winnow.query(fixture, options)
+  t.equal(Object.keys(result.features[0].attributes).length, 1)
+  t.equal(result.features[0].attributes.hasOwnProperty('string'), true)
+  t.end()
+})
+
+test('do not exclude objectid when returnIdsOnly = true', t => {
+  const options = {
+    toEsri: true,
+    outFields: ['string'],
+    returnIdsOnly: true
+  }
+  const fixture = _.cloneDeep(geojson)
+  const result = Winnow.query(fixture, options)
+  t.equal(Object.keys(result.features[0].attributes).length, 2)
+  t.equal(result.features[0].attributes.hasOwnProperty('string'), true)
+  t.equal(result.features[0].attributes.hasOwnProperty('OBJECTID'), true)
   t.end()
 })

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -49,7 +49,11 @@ test('With a where option and a limit the same as the the filter', t => {
   }
   const result = Winnow.query(trees, options)
   const metadata = result.metadata
-  t.notOk(metadata.limitExceeded)
+  // NOTE: By shifting the limit to SQL, we can no longer be sure if # of features returned is
+  // due to LIMIT or WHERE; most likely it will be due to limit, so logic set limitExceeded to
+  // true whenever (options.limit && features.length > filtered length
+
+  t.ok(metadata.limitExceeded)
   t.end()
 })
 
@@ -96,7 +100,7 @@ test('adding an object id', t => {
   }
   const fixture = _.cloneDeep(geojson)
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.OBJECTID, 2081706708)
+  t.equal(result.features[0].attributes.OBJECTID, 239375164)
   t.end()
 })
 

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -49,11 +49,7 @@ test('With a where option and a limit the same as the the filter', t => {
   }
   const result = Winnow.query(trees, options)
   const metadata = result.metadata
-  // NOTE: By shifting the limit to SQL, we can no longer be sure if # of features returned is
-  // due to LIMIT or WHERE; most likely it will be due to limit, so logic set limitExceeded to
-  // true whenever (options.limit && features.length > filtered length
-
-  t.ok(metadata.limitExceeded)
+  t.notOk(metadata.limitExceeded)
   t.end()
 })
 


### PR DESCRIPTION
Currently, standard and limit queries have SQL applied to raw data set feature by feature.  This facilitates the application of the `esriFy` function (it needs the full geometry and property set), but means that ordering, limit and offset functionality are completed post-SQL query as well.  This complicates ordered paging, because an iterative sort is required on the full feature set, prior to applying the limit and offset.

As an alternative, I moved the `esriFy` into the SQL execution.  This allows the SQL to be applied to the full feature set, and which allows the leveraging of the SQL for ORDER BY, LIMIT and OFFSET.

~The only downside I discovered was in calculation of the `limitExceeded` property.   For queries that include both a `limit` and a `where`, it's not possible to discern whether the result feature set length is a result of the imposed `limit` or if its coincidentally the result of the application of the `where`.  In order to keep reporting `limitExceeded`, the code in the PR always reports it as `true` when the feature subset equals the `limit` and when the raw feature set is greater than the limited subset.~