### PR TITLE
Change farmhash to an optional dependency and add fall back to string-hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@turf/centroid": "^6.0.0",
     "alasql": "^0.4.0",
     "classybrew": "0.0.3",
-    "farmhash": "^2.0.5",
     "flora-sql-parser": "^0.7.5",
     "highland": "^3.0.0-beta.3",
     "lodash": "^4.17.4",
@@ -44,6 +43,7 @@
     "proj4": "^2.3.17",
     "simple-statistics": "^6.0.0",
     "srs": "^1.2.0",
+    "string-hash": "^1.1.3",
     "terraformer": "^1.0.7"
   },
   "devDependencies": {
@@ -52,5 +52,8 @@
     "standard": "^11.0.0",
     "tap-spec": "^5.0.0",
     "tape": "^4.6.3"
+  },
+  "optionalDependencies": {
+    "farmhash": "^2.1.0"
   }
 }

--- a/src/executeQuery.js
+++ b/src/executeQuery.js
@@ -1,9 +1,16 @@
 'use strict'
-const farmhash = require('farmhash')
 const sql = require('./sql')
 const Query = require('./query')
 const { calculateClassBreaks, calculateUniqueValueBreaks } = require('./generateBreaks/index')
 const _ = require('lodash')
+
+// Try to require farmhash, as it is an optional depenecy we can fall back to JavaScript only hashing library
+let hashFunction
+try {
+  hashFunction = require('farmhash').hash32
+} catch (e) {
+  hashFunction = require('string-hash')
+}
 
 function breaksQuery (features, query, options) {
   const queriedData = standardQuery(features, query, options)
@@ -117,7 +124,7 @@ function finishQuery (features, options) {
  */
 function createIntHash (inputStr) {
   // Hash to 32 bit unsigned integer
-  const hash = farmhash.hash32(inputStr)
+  const hash = hashFunction(inputStr)
   // Normalize to range of postive values of signed integer
   return Math.round((hash / 4294967295) * (2147483647))
 }

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -96,7 +96,18 @@ test('adding an object id', t => {
   }
   const fixture = _.cloneDeep(geojson)
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.OBJECTID, 2081706708)
+
+  // A different hash can be returned depending on the library used
+  let hash
+  try {
+    // If requiring farmhash is successful we use that hash
+    require('farmhash')
+    hash = 2081706708
+  } catch (e) {
+    // Else use the string-hash number
+    hash = 288691680
+  }
+  t.equal(result.features[0].attributes.OBJECTID, hash)
   t.end()
 })
 


### PR DESCRIPTION
Hi there, I am trying to build a version of Koop in an environment where I am not able to compile native node modules, this means I can't use the most up-to-date version of Koop due to winnow's dependency on farmhash.

This PR makes the native farmhash module optional, adding a fallback to a pure JavaScript hashing library when farmhash is not installed. This means those that cannot or don't want to use native modules can still use winnow, while others can still take advantage of farmhash's superior speed.

I roughly followed the instructions for optional dependencies on [npm](https://docs.npmjs.com/files/package.json#optionaldependencies) but let me know if you'd rather I implemented it in a different way.

Thanks!