### PR TITLE
Remove node-srs from `normalizeSR` function.  Add in Esri lookups to get…

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@turf/centroid": "^6.0.0",
     "alasql": "^0.4.0",
     "classybrew": "0.0.3",
+    "esri-proj-codes": "^1.0.3",
     "flora-sql-parser": "^0.7.5",
     "highland": "^3.0.0-beta.3",
     "lodash": "^4.17.4",
@@ -42,9 +43,9 @@
     "ngeohash": "^0.6.0",
     "proj4": "^2.3.17",
     "simple-statistics": "^6.0.0",
-    "srs": "^1.2.0",
     "string-hash": "^1.1.3",
-    "terraformer": "^1.0.7"
+    "terraformer": "^1.0.7",
+    "wkt-parser": "^1.2.2"
   },
   "devDependencies": {
     "buble": "^0.19.0",

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -66,6 +66,18 @@ test('normalize SR with a 102100 number', t => {
   t.equal(SR.wkid, 3857)
 })
 
+test('normalize SR wkid 2855 with wkt - uses @esri/proj-codes', t => {
+  t.plan(1)
+  const SR = normalizeSR(2855)
+  t.equal(SR.wkt, `PROJCS["NAD_1983_HARN_StatePlane_Washington_North_FIPS_4601",GEOGCS["GCS_North_American_1983_HARN",DATUM["D_North_American_1983_HARN",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",500000.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-120.8333333333333],PARAMETER["Standard_Parallel_1",47.5],PARAMETER["Standard_Parallel_2",48.73333333333333],PARAMETER["Latitude_Of_Origin",47.0],UNIT["Meter",1.0]]`)
+})
+
+test('normalize SR wkid 102645 with wkt - uses esri-proj-codes', t => {
+  t.plan(1)
+  const SR = normalizeSR(102645)
+  t.equal(SR.wkt, `PROJCS["NAD_1983_StatePlane_California_V_FIPS_0405_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",6561666.666666666],PARAMETER["False_Northing",1640416.666666667],PARAMETER["Central_Meridian",-118.0],PARAMETER["Standard_Parallel_1",34.03333333333333],PARAMETER["Standard_Parallel_2",35.46666666666667],PARAMETER["Latitude_Of_Origin",33.5],UNIT["Foot_US",0.3048006096012192]]`)
+})
+
 test('normalize SR with a State Plane wkt', t => {
   t.plan(1)
   const wkt = `PROJCS["NAD_1983_StatePlane_California_V_FIPS_0405_Feet",


### PR DESCRIPTION
Currently, winnow is leveraging node-srs to parse WKTs.  This is undesirable because it relies on GDAL, a native module.  

This PR:
1) removes the node-srs dependency
2) Adds a check for `WGS_1984_Web_Mercator_Auxiliary_Sphere` and returns 3857.
3) Adds an Esri WKT lookup for WKIDs that are unknown to proj4.  (The omission of this in current code base is a bug - e.g.,  a valid WKID like 2855 get redefined as 4326 because 2855 is not found in proj4's list of known WKIDs).