### PR TITLE
Handle comma delimited orderByFields.

### DIFF
--- a/src/options/normalizeSQL.js
+++ b/src/options/normalizeSQL.js
@@ -27,7 +27,8 @@ function normalizeFields (options) {
 
 function normalizeOrder (options) {
   const order = options.order || options.orderByFields
-  return typeof order === 'string' ? [order] : order
+  if (!order) return
+  return order instanceof Array ? [order] : order.split(',').map(item => item.trim())
 }
 
 function normalizeAggregates (options) {


### PR DESCRIPTION
This PR splits incoming `orderByFields` parameter by `,` if it is a string.  Before now, the string was simply being placed in the first item of the array.  This may have worked when ordering was being done post-alasql, but now it is incompatible.