### PR TITLE
Fix payloads when idField is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Removed workaround for adding and `OBJECTID` field even when metadata `idField` is set
+
 ## [1.16.4] - 09-13-2018
 ### Fixed
 * Parse comma delimited `orderByFields` parameter and trim any white space.

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -12,7 +12,8 @@ const {
   normalizeLimit,
   normalizeGeometry,
   normalizeOffset,
-  normalizeProjection
+  normalizeProjection,
+  normalizeIdField
 
 } = require('./normalizeOptions')
 const { normalizeClassification } = require('./normalizeClassification')
@@ -20,6 +21,7 @@ const { normalizeClassification } = require('./normalizeClassification')
 function prepare (options, features) {
   const prepared = _.merge({}, options, {
     collection: normalizeCollection(options, features),
+    idField: normalizeIdField(options, features),
     where: normalizeWhere(options),
     geometry: normalizeGeometry(options),
     spatialPredicate: normalizeSpatialPredicate(options),
@@ -33,7 +35,6 @@ function prepare (options, features) {
   })
   prepared.offset = normalizeOffset(options)
   prepared.dateFields = normalizeDateFields(prepared.collection, prepared.fields)
-  prepared.idField = _.get(prepared.collection, 'metadata.idField') || null
   if (prepared.where === '1=1') delete prepared.where
 
   return prepared

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -217,8 +217,8 @@ function normalizeIdField (options, features = []) {
 
   // Check metadata.fields for and OBJECTID property
   else if (_.find(metadata.fields, { name: 'OBJECTID' })) idField = 'OBJECTID'
-  // Check features for an OBJECTID property
-  else if (features.length > 0 && featureProperties.OBJECTID) idField = 'OBJECTID'
+  // Check features for an OBJECTID property that is not null
+  else if (features.length > 0 && !_.isUndefined(featureProperties.OBJECTID) && !_.isNull(featureProperties.OBJECTID)) idField = 'OBJECTID'
 
   // If there are features, check that the idField is one of the properties
   if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress' && features.length > 0 && !featureProperties[idField]) {

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -221,8 +221,8 @@ function normalizeIdField (options, features = []) {
   else if (features.length > 0 && !_.isUndefined(featureProperties.OBJECTID) && !_.isNull(featureProperties.OBJECTID)) idField = 'OBJECTID'
 
   // If there are features, check that the idField is one of the properties
-  if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress' && features.length > 0 && !featureProperties[idField]) {
-    console.warn(`WARNING: requested provider has "idField" assignment, but this property is not found in every features properties.`)
+  if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress' && idField && features.length > 0 && !featureProperties[idField]) {
+    console.warn(`WARNING: requested provider has "idField" assignment, but this property is not found in properties of all features.`)
   }
 
   return idField

--- a/src/options/normalizeOptions.js
+++ b/src/options/normalizeOptions.js
@@ -14,19 +14,17 @@ const esriPredicates = {
 }
 const wkidLookup = {}
 
-function normalizeCollection (options, features = []) {
+function normalizeCollection (options = {}, features = []) {
   if (!options.collection) return undefined
+
+  // Make a new copy of the collection so we don't modify the original
   const collection = _.cloneDeep(options.collection)
-  const metadata = collection.metadata || {}
-  if (!metadata.fields && features[0]) metadata.fields = detectFieldsType(features[0].properties)
-  let oidField
-  if (features[0]) {
-    oidField = Object.keys(features[0].properties).filter(key => {
-      return /objectid/i.test(key)
-    })[0]
-  }
-  if (oidField && !metadata.idField) metadata.idField = oidField
-  collection.metadata = metadata
+  collection.metadata = collection.metadata || {}
+
+  // If fields haven't been set in metadata and there is at least one feature, determine
+  // field set from a feature properties
+  if (!collection.metadata.fields && features[0]) collection.metadata.fields = detectFieldsType(features[0].properties)
+
   return collection
 }
 
@@ -203,6 +201,33 @@ function normalizeProjection (options) {
   else return `EPSG:${projection}`
 }
 
+/**
+ * Ensure idField is set if metadata doesn't have a value but a field named OBJECTID is present
+ * @param {object} metadata
+ */
+function normalizeIdField (options, features = []) {
+  const collection = options.collection || {}
+  const metadata = collection.metadata || {}
+  const feature = features[0] || {}
+  const featureProperties = feature.properties || feature.attributes || {}
+  let idField = null
+
+  // First, check metadata for idField
+  if (metadata.idField) idField = metadata.idField
+
+  // Check metadata.fields for and OBJECTID property
+  else if (_.find(metadata.fields, { name: 'OBJECTID' })) idField = 'OBJECTID'
+  // Check features for an OBJECTID property
+  else if (features.length > 0 && featureProperties.OBJECTID) idField = 'OBJECTID'
+
+  // If there are features, check that the idField is one of the properties
+  if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress' && features.length > 0 && !featureProperties[idField]) {
+    console.warn(`WARNING: requested provider has "idField" assignment, but this property is not found in every features properties.`)
+  }
+
+  return idField
+}
+
 module.exports = {
   normalizeCollection,
   normalizeDateFields,
@@ -213,5 +238,6 @@ module.exports = {
   normalizeProjection,
   normalizeSR,
   normalizeInSR,
-  normalizeSourceSR
+  normalizeSourceSR,
+  normalizeIdField
 }

--- a/src/options/normalizeSQL.js
+++ b/src/options/normalizeSQL.js
@@ -1,3 +1,5 @@
+const _ = require('lodash')
+
 function normalizeWhere (options) {
   if (/1\s*=\s*1/.test(options.where)) return undefined
   else if (/(?!date )('?\d\d\d\d-\d\d-\d\d'?)/.test(options.where)) return normalizeDate(options.where)
@@ -18,8 +20,10 @@ function normalizeDate (where) {
  */
 function normalizeFields (options) {
   const fields = options.fields || options.outFields
+  const idField = _.get(options, 'collection.metadata.idField')
+  if (options.returnIdsOnly === true && idField) return [idField]
+  else if (options.returnIdsOnly === true) return ['OBJECTID']
   if (fields === '*') return undefined
-  if (options.returnIdsOnly === true) return ['OBJECTID']
   if (typeof fields === 'string' || fields instanceof String) return fields.split(',')
   if (fields instanceof Array) return fields
   return undefined

--- a/src/sql.js
+++ b/src/sql.js
@@ -143,7 +143,7 @@ function esriFy (properties, geometry, dateFields, requiresObjectId, idField) {
     if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress' && (!Number.isInteger(properties[idField]) || properties[idField] > 2147483647)) {
       console.warn(`WARNING: OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)
     }
-    properties.OBJECTID = properties[idField]
+    // properties.OBJECTID = properties[idField]
   } else {
     // Create an OBJECTID by creating a numeric hash from the stringified feature
     // Note possibility of OBJECTID collisions with this method still exists, but should be small

--- a/src/sql.js
+++ b/src/sql.js
@@ -143,7 +143,6 @@ function esriFy (properties, geometry, dateFields, requiresObjectId, idField) {
     if (process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress' && (!Number.isInteger(properties[idField]) || properties[idField] > 2147483647)) {
       console.warn(`WARNING: OBJECTIDs created from provider's "idField" are not integers from 0 to 2147483647`)
     }
-    // properties.OBJECTID = properties[idField]
   } else {
     // Create an OBJECTID by creating a numeric hash from the stringified feature
     // Note possibility of OBJECTID collisions with this method still exists, but should be small

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -1,5 +1,40 @@
 const test = require('tape')
-const { normalizeSR, normalizeInSR, normalizeSourceSR } = require('../src/options/normalizeOptions')
+const _ = require('lodash')
+
+const {
+  normalizeCollection,
+  // TODO: Put these under test
+  // normalizeDateFields,
+  // normalizeSpatialPredicate,
+  // normalizeLimit,
+  // normalizeGeometry,
+  // normalizeOffset,
+  // normalizeProjection,
+  normalizeSR,
+  normalizeInSR,
+  normalizeSourceSR,
+  normalizeIdField
+} = require('../src/options/normalizeOptions')
+
+test('normalize collection without metadata', t => {
+  t.plan(1)
+  const collection = normalizeCollection({ collection: {} })
+  t.equals(_.isObject(collection.metadata), true, 'collection has a metadata object')
+})
+
+test('normalize collection with metadata when features are supplied', t => {
+  t.plan(1)
+  const options = { collection: {} }
+  const features = [
+    {
+      properties: {
+        feature_id: 1
+      }
+    }
+  ]
+  const collection = normalizeCollection(options, features)
+  t.equals(Array.isArray(collection.metadata.fields), true, 'collection has a metadata fields array')
+})
 
 test('normalize SR with a wkid in the known list', t => {
   t.plan(1)
@@ -179,4 +214,49 @@ test('normalize source data SR with unknown wkid, default to 4326', t => {
   const options = { inSR: { wkid: 9999 } }
   const sourceSR = normalizeInSR(options)
   t.equal(sourceSR, `EPSG:4326`)
+})
+
+test('normalize idField when set with metadata', t => {
+  t.plan(1)
+  const options = { collection: { metadata: { idField: 'feature_id' } } }
+  const idField = normalizeIdField(options)
+  t.equals(idField, 'feature_id', 'idField set properly with metadata')
+})
+
+test('normalize idField with OBJECTID from feature properties', t => {
+  t.plan(1)
+  const options = {}
+  const features = [
+    {
+      properties: {
+        OBJECTID: 1
+      }
+    }
+  ]
+  const idField = normalizeIdField(options, features)
+  t.equals(idField, 'OBJECTID', 'idField defaulted to OBJECTID when found as feature property')
+})
+
+test('normalize idField with metadata.fields', t => {
+  t.plan(1)
+  const options = {
+    collection: {
+      metadata: {
+        fields: [
+          {
+            name: 'OBJECTID'
+          }
+        ]
+      }
+    }
+  }
+  const features = [
+    {
+      properties: {
+        OBJECTID: 1
+      }
+    }
+  ]
+  const idField = normalizeIdField(options, features)
+  t.equals(idField, 'OBJECTID', 'idField defaulted to OBJECTID when found in metadata.fields')
 })

--- a/test/normalizeOptions.js
+++ b/test/normalizeOptions.js
@@ -260,3 +260,40 @@ test('normalize idField with metadata.fields', t => {
   const idField = normalizeIdField(options, features)
   t.equals(idField, 'OBJECTID', 'idField defaulted to OBJECTID when found in metadata.fields')
 })
+
+test('normalize idField with metadata.fields', t => {
+  t.plan(1)
+  const options = {
+    collection: {
+      metadata: {
+        fields: [
+          {
+            name: 'OBJECTID'
+          }
+        ]
+      }
+    }
+  }
+  const features = [
+    {
+      properties: {
+        OBJECTID: 1
+      }
+    }
+  ]
+  const idField = normalizeIdField(options, features)
+  t.equals(idField, 'OBJECTID', 'idField defaulted to OBJECTID when found in metadata.fields')
+})
+
+test('normalize idField with metadata.idField = null', t => {
+  t.plan(1)
+  const options = {
+    collection: {
+      metadata: {
+        idField: null
+      }
+    }
+  }
+  const idField = normalizeIdField(options)
+  t.equals(idField, null, 'idField return as null')
+})

--- a/test/normalizeSQL.js
+++ b/test/normalizeSQL.js
@@ -1,0 +1,67 @@
+const test = require('tape')
+const { normalizeFields } = require('../src/options/normalizeSQL')
+
+// TODO: put other functions from normalize fields under test
+
+test('normalize fields when value is "*"', t => {
+  t.plan(1)
+  const options = {
+    fields: '*'
+  }
+  const fields = normalizeFields(options)
+  t.equals(fields, undefined, 'is undefined')
+})
+
+test('normalize fields when value is "test,field,names"', t => {
+  t.plan(2)
+  const options = {
+    fields: 'test,field,names'
+  }
+  const fields = normalizeFields(options)
+  t.ok(Array.isArray(fields), 'is an array')
+  t.deepEquals(fields, ['test', 'field', 'names'], 'has expected contents')
+})
+
+test(`normalize fields when value is "['test', 'field', 'names']"`, t => {
+  t.plan(2)
+  const options = {
+    fields: ['test', 'field', 'names']
+  }
+  const fields = normalizeFields(options)
+  t.ok(Array.isArray(fields), 'is an array')
+  t.deepEquals(fields, ['test', 'field', 'names'], 'has expected contents')
+})
+
+test('normalize fields when value options has "outFields" rather thatn "fields', t => {
+  t.plan(1)
+  const options = {
+    outFields: '*'
+  }
+  const fields = normalizeFields(options)
+  t.equals(fields, undefined, 'should be undefined')
+})
+
+test('normalize fields when returnIdsOnly is set to true and an idField is set', t => {
+  t.plan(1)
+  const options = {
+    returnIdsOnly: true,
+    outFields: '*',
+    collection: {
+      metadata: {
+        idField: 'feature_id'
+      }
+    }
+  }
+  const fields = normalizeFields(options)
+  t.equals(fields[0], 'feature_id', 'is the idField')
+})
+
+test('normalize fields when returnIdsOnly is set to true and an idField is not set', t => {
+  t.plan(1)
+  const options = {
+    returnIdsOnly: true,
+    outFields: '*'
+  }
+  const fields = normalizeFields(options)
+  t.equals(fields[0], 'OBJECTID', 'is OBJECTID')
+})

--- a/test/options.js
+++ b/test/options.js
@@ -33,3 +33,14 @@ test('handle a query with no returned features', t => {
   const prepared = prepare(options, features)
   t.equal(prepared.collection.metadata.idField, undefined)
 })
+
+test('handle a query with no features but options returnIdsOnly andidField set in metadata', t => {
+  t.plan(3)
+  const options = { toEsri: true, returnIdsOnly: true, collection: { metadata: { idField: 'feature_id' }, type: 'FeatureCollection' } }
+  const features = []
+
+  const prepared = prepare(options, features)
+  t.equal(prepared.collection.metadata.idField, 'feature_id')
+  t.equal(prepared.idField, 'feature_id')
+  t.equal(prepared.fields[0], 'feature_id')
+})

--- a/test/to-esri.js
+++ b/test/to-esri.js
@@ -70,23 +70,23 @@ test('checking if an object id exists', t => {
   }
   const fixture = _.cloneDeep(oidFeature)
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.OBJECTID, 1)
-  t.equal(result.metadata.idField, 'objectid')
+  t.equal(result.features[0].attributes.OBJECTID, 1430702552)
+  t.equal(result.metadata.idField, undefined)
   t.end()
 })
 
 test('use idField not name OBJECTID', t => {
   const options = {
     toEsri: true,
-    fields: 'OBJECTID'
+    fields: 'featureId'
   }
   const fixture = _.cloneDeep(treesFeatureId)
   fixture.metadata = {
     idField: 'featureId'
   }
   const result = Winnow.query(fixture, options)
-  t.equal(result.features[0].attributes.hasOwnProperty('OBJECTID'), true)
-  t.equal(result.features[0].attributes.OBJECTID, 11303)
+  t.equal(result.features[0].attributes.hasOwnProperty('featureId'), true)
+  t.equal(result.features[0].attributes.featureId, 11303)
   t.equal(result.metadata.idField, 'featureId')
   t.end()
 })


### PR DESCRIPTION
This PR removes a workaround (implemented 5 or 6 months ago) that helped get koop working on ArcGIS clients.  The workaround added an`OBJECTID` field to payloads even if a provider had set `idField` in the provider metadata.  The result was two properties with the same value. This is not ideal, for reasons noted in https://github.com/koopjs/FeatureServer/issues/127.

I've identified the original bug - it was in queries that had `returnIdsOnly=true`.  When that parameter was set, `outFields` were forced to `OBJECTID` even if `idField` had been set in the provider.  That bug is fixed and the workaround is not removed.  If `idField` is set a duplicate property `OBJECTID` is no longer added.

I've added some test coverage for the normalization functions that were added or modified.

NOTE: there will be a companion PR on FeatureServer required to make this fix effective on koop deployments.
