### PR TITLE
Handle where queries on OBJECTID when OBJECTID is generated on the fly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+## Fixed
+* Support for using OBJECTID in `where` even when OBJECTIDs are generated on-the-fly in Winnow
+
 ## [1.16.6] - 03-25-2019
 ### Changed
 * Geometry envelopes are constructed in counter-clockwise ring

--- a/src/sql.js
+++ b/src/sql.js
@@ -152,6 +152,19 @@ function esriFy (properties, geometry, dateFields, requiresObjectId, idField) {
 }
 
 /**
+ *
+ */
+sql.fn.hashedObjectIdComparator = function (properties, geometry, objectId, operator) {
+  const hash = createIntHash(JSON.stringify({ properties, geometry }))
+  if (operator === '=' && hash === objectId) return true
+  else if (operator === '>' && hash > objectId) return true
+  else if (operator === '<' && hash < objectId) return true
+  else if (operator === '>=' && hash >= objectId) return true
+  else if (operator === '<=' && hash <= objectId) return true
+  return false
+}
+
+/**
  * Create integer hash in range of 0 - 2147483647 from string
  * @param {*} inputStr - any string
  */

--- a/src/where.js
+++ b/src/where.js
@@ -170,8 +170,8 @@ function createClause (options) {
 }
 
 /**
- * If the WHERE contains fragments with OBJECTID, but the data doesn't containg an OBJECTID field,
- * and no substituation is made with the "idField" property, we must replace these WHERE fragments
+ * If the WHERE contains fragments with OBJECTID, but the data doesn't contain an OBJECTID field,
+ * and no substitution is made with the "idField" property, we must replace these WHERE fragments
  * with use a user-defined function that will calculate the OBJECTID on the fly, do the apropriate
  * comparison, and return the resulting boolean value
  * @param {string} input

--- a/src/where.js
+++ b/src/where.js
@@ -179,11 +179,15 @@ function createClause (options) {
  */
 function translateObjectIdFragments (input, options = {}) {
   let where = input
+  const { idField } = options
 
   // Check if OBJECTID is one of the GeoJSON properties
   const metadataObjectIdField = _.get(options, 'collection.metadata.fields', []).find(field => { return field.name === 'OBJECTID' })
 
-  if (where.includes('OBJECTID') && !metadataObjectIdField) {
+  // If the WHERE includes predicates with OBJECTID, but no OBJECTID is defined on the data,
+  // and no `idField` has been assigned, we have to use a user-defined function to generate
+  // an on-the-fly OBJECTID for comparison to the request's value
+  if (where.includes('OBJECTID') && !metadataObjectIdField && !idField) {
     // RegExp for name-first predicate, e.g "properties->`OBJECTID` = 1234"
     const regexOid1st = /(properties|attributes)->`OBJECTID` (=|<|>|<=|>=) ([0-9]+)/g
 

--- a/src/where.js
+++ b/src/where.js
@@ -172,7 +172,7 @@ function createClause (options) {
 /**
  * If the WHERE contains fragments with OBJECTID, but the data doesn't contain an OBJECTID field,
  * and no substitution is made with the "idField" property, we must replace these WHERE fragments
- * with use a user-defined function that will calculate the OBJECTID on the fly, do the apropriate
+ * with use a user-defined function that will calculate the OBJECTID on the fly, do the appropriate
  * comparison, and return the resulting boolean value
  * @param {string} input
  * @param {object} options

--- a/test/where.js
+++ b/test/where.js
@@ -1,6 +1,5 @@
 'use strict'
 const test = require('tape')
-const _ = require('lodash')
 const where = require('../src/where')
 
 test('Transform a simple equality predicate', t => {

--- a/test/where.js
+++ b/test/where.js
@@ -1,0 +1,31 @@
+'use strict'
+const test = require('tape')
+const _ = require('lodash')
+const where = require('../src/where')
+
+test('Transform a simple equality predicate', t => {
+  t.plan(1)
+  const options = {
+    where: `foo='bar'`
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `properties->\`foo\` = 'bar'`)
+})
+
+test('Transform a simple but inverse predicate', t => {
+  t.plan(1)
+  const options = {
+    where: `'bar'=foo`
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `'bar' = properties->\`foo\``)
+})
+
+test('Transform a simple predicate', t => {
+  t.plan(1)
+  const options = {
+    where: `'bar'=foo`
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `'bar' = properties->\`foo\``)
+})

--- a/test/where.js
+++ b/test/where.js
@@ -28,3 +28,75 @@ test('Transform a simple predicate', t => {
   const whereFragment = where.createClause(options)
   t.equals(whereFragment, `'bar' = properties->\`foo\``)
 })
+
+test('Transform a simple predicate to Esri flavor', t => {
+  t.plan(1)
+  const options = {
+    where: `foo='bar'`,
+    esri: true
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `attributes->\`foo\` = 'bar'`)
+})
+
+test('Transform a simple but inverse predicate to Esri flavor', t => {
+  t.plan(1)
+  const options = {
+    where: `'bar'=foo`,
+    esri: true
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `'bar' = attributes->\`foo\``)
+})
+
+test('Transform a predicate with OBJECTID and no metadata fields to user-defined function', t => {
+  t.plan(1)
+  const options = {
+    where: `OBJECTID=1234`
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `hashedObjectIdComparator(properties, geometry, 1234, '=')=true`)
+})
+
+test('Transform a predicate with OBJECTID and no metadata fields to Esri flavor with user-defined function', t => {
+  t.plan(1)
+  const options = {
+    where: `OBJECTID=1234`,
+    esri: true
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `hashedObjectIdComparator(attributes, geometry, 1234, '=')=true`)
+})
+
+test('Transform an inverse predicate with OBJECTID and no metadata fields to user-defined function', t => {
+  t.plan(1)
+  const options = {
+    where: `1234>OBJECTID`
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `hashedObjectIdComparator(properties, geometry, 1234, '<=')=true`)
+})
+
+test('Transform an inverse predicate with OBJECTID and no metadata fields to Esri flavor with user-defined function', t => {
+  t.plan(1)
+  const options = {
+    where: `1234>OBJECTID`,
+    esri: true
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `hashedObjectIdComparator(attributes, geometry, 1234, '<=')=true`)
+})
+
+test('Transform a predicate with OBJECTID and metadata fields that define the OBJECTID', t => {
+  t.plan(1)
+  const options = {
+    where: `OBJECTID=1234`,
+    collection: {
+      metadata: {
+        fields: [{ name: 'OBJECTID' }]
+      }
+    }
+  }
+  const whereFragment = where.createClause(options)
+  t.equals(whereFragment, `properties->\`OBJECTID\` = 1234`)
+})


### PR DESCRIPTION
The PR addresses a deficiency in current code base that prevents ability to query on OBJECTID in the `where` parameter when OBJECTIDs are generated on-the-fly in Winnow.

**Context:**
If data arrives in winnow _without_ an OBJECTID field and no alternative assignment using the `metadata.idField` property, then winnow generates an OBJECTID on-the-fly in a user-defined `SELECT` function that is passed into alasql.  However, problems occur if the `where` parameter queries OBJECTID, e.g., `where=OBJECTID=1234`, because the OBJECTID does not yet exist on the data when the alasql `WHERE` does its filtering.  Thus, no features are ever returned.

**Solution:**
If the WHERE includes predicates with OBJECTID, but no OBJECTID is defined on the data, and no `idField` has been assigned, we have to use a user-defined function in the `WHERE` part of alasql to generate an on-the-fly OBJECTID for comparison to the submitted value.
