### PR TITLE
Fix group by with where clause.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Fix SQL generated when using group by with where clause.
+
 ## [1.16.9] - 08-02-2019
 ### Fixed
 * ST_Within had geometry targets reversed. Now tests that feature is within filter.

--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -1,0 +1,14 @@
+function createClause (options) {
+  const groupBy = options.groupBy
+  if (groupBy) {
+    const selector = options.esri ? 'attributes' : 'properties'
+    const groups = groupBy.reduce((fragment, group) => {
+      return `${fragment} ${selector}->\`${group}\`,`
+    }, '').slice(0, -1)
+    return ` GROUP BY ${groups}`
+  } else {
+    return ''
+  }
+}
+
+module.exports = { createClause }

--- a/src/query.js
+++ b/src/query.js
@@ -3,17 +3,20 @@ const Geometry = require('./geometry')
 const Where = require('./where')
 const Select = require('./select')
 const Order = require('./order')
+const GroupBy = require('./groupBy')
 
 function create (options) {
   let query = Select.createClause(options)
   const where = Where.createClause(options)
   const geomFilter = Geometry.createClause(options)
   const order = Order.createClause(options)
+  const groupBy = GroupBy.createClause(options)
   if (options.where || options.geometry) query += ' WHERE '
   if (options.where) query += where
   if (options.geometry && !where) query += geomFilter
   if (options.geometry && where) query += ` AND ${geomFilter}`
   // if (options.aggregates) return query
+  if (options.groupBy && groupBy) query += groupBy
   if (options.order || options.orderByFields) query += order
   if (options.limit) query += ` LIMIT ${options.limit}`
   if (options.offset) query += ` OFFSET ${options.offset}` // handled in executeQuery.js

--- a/src/select/aggregates.js
+++ b/src/select/aggregates.js
@@ -14,13 +14,9 @@ module.exports = function (aggregates, groupBy, esri) {
 }
 
 function addGroupBy (select, groupBy, selector) {
-  const groups = groupBy.reduce((fragment, group) => {
-    return `${fragment} ${selector}->\`${group}\`,`
-  }, '').slice(0, -1)
-
   const fields = groupBy.reduce((fragment, group) => {
     return `${fragment} ${selector}->\`${group}\` as \`${group}\`,`
   }, '').slice(0, -1)
 
-  return `${select.slice(0, -1)}, ${fields} FROM ? GROUP BY ${groups}`
+  return `${select.slice(0, -1)}, ${fields} FROM ? `
 }

--- a/test/aggregate.js
+++ b/test/aggregate.js
@@ -88,6 +88,24 @@ test('Use multiple group bys', t => {
   t.ok(results[0].avg_Trunk_Diameter)
 })
 
+test('Use a group by with a where clause', t => {
+  t.plan(3)
+  const options = {
+    aggregates: [
+      {
+        type: 'avg',
+        field: 'Trunk_Diameter'
+      }
+    ],
+    where: 'Trunk_Diameter > 10',
+    groupBy: 'Genus'
+  }
+  const results = winnow.query(features, options)
+  t.equal(results.length, 127)
+  t.ok(results[0].Genus)
+  t.ok(results[0].avg_Trunk_Diameter)
+})
+
 test('Get a named aggregate', t => {
   t.plan(1)
   const options = {


### PR DESCRIPTION
The SQL query created when using a GROUP BY with a
WHERE clause was invalid, the GROUP BY was before
the WHERE clause. This resulted in alasql failing
to parse the query.

Fixed to separate adding the GROUP BY fields in the
SELECT clause, and adding the actual GROUP BY clause
later after the WHERE clause.

Added unit test to cover the changes.

Before the change, the generate SQL query looked like
this:

  SELECT AVG(properties->`Trunk_Diameter`) as `avg_Trunk_Diameter`,
         properties->`Genus` as `Genus`
  FROM ?
  GROUP BY  properties->`Genus`
  WHERE properties->`Trunk_Diameter` > 10

After it looks like this:

  SELECT AVG(properties->`Trunk_Diameter`) as `avg_Trunk_Diameter`,
         properties->`Genus` as `Genus`
  FROM ?
  WHERE properties->`Trunk_Diameter` > 10
  GROUP BY  properties->`Genus`