### PR TITLE
Split groupByFieldsForStatistics by comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Split comma delimited group by fields
+
 ## [1.16.9] - 08-02-2019
 ### Fixed
 * ST_Within had geometry targets reversed. Now tests that feature is within filter.

--- a/src/options/normalizeSQL.js
+++ b/src/options/normalizeSQL.js
@@ -59,7 +59,7 @@ function normalizeAggregates (options) {
 
 function normalizeGroupBy (options) {
   const groupBy = options.groupBy || options.groupByFieldsForStatistics
-  return typeof groupBy === 'string' ? [groupBy] : groupBy
+  return typeof groupBy === 'string' ? groupBy.split(',') : groupBy
 }
 
 module.exports = { normalizeWhere, normalizeFields, normalizeOrder, normalizeAggregates, normalizeGroupBy }

--- a/test/aggregate.js
+++ b/test/aggregate.js
@@ -88,6 +88,24 @@ test('Use multiple group bys', t => {
   t.ok(results[0].avg_Trunk_Diameter)
 })
 
+test('Use multiple group bys ESRI style', t => {
+  t.plan(4)
+  const options = {
+    aggregates: [
+      {
+        type: 'avg',
+        field: 'Trunk_Diameter'
+      }
+    ],
+    groupByFieldsForStatistics: 'Genus,Common_Name'
+  }
+  const results = winnow.query(features, options)
+  t.equal(results.length, 310)
+  t.ok(results[0].Genus)
+  t.ok(results[0].Common_Name)
+  t.ok(results[0].avg_Trunk_Diameter)
+})
+
 test('Get a named aggregate', t => {
   t.plan(1)
   const options = {


### PR DESCRIPTION
ArcGIS Operations Dashboard allows you to create a Serial Chart,
grouping the data one field, and splitting the bars by a second. The
queries it sends to the feature service are comma separated. This was
being treated by winnow as a single field name containing a comma,
instead of splitting the parameter into a list of field names.

Updated the normalizeGroupBy function to split the parameter with the
comma character. (I've done this for both 'groupBy' and
'groupByFieldsForStatistics', could maybe restrict it to only do it for
the Esri 'groupByFieldsForStatistics' property?)

Added unit test to cover it.