### PR TITLE
Bump travis node to 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- "8"
+- "10"
 sudo: false
 cache:
 - node_modules


### PR DESCRIPTION
Travis builds are failing on the test command with node < 10.  However, tests pass outside Travis environment with node 8, so this seems unique to Travis environment.  Bumping node travis uses to 10.