### PR TITLE
Refactor date-fields query option.

### DIFF
--- a/lib/normalize-query-options/date-fields.js
+++ b/lib/normalize-query-options/date-fields.js
@@ -3,7 +3,7 @@ const _ = require('lodash')
  * @param {object} collection - the GeoJSON object from Koop (with features omitted)
  * @param {*} requestedFields
  */
-function getDateFields (collection, requestedFields) {
+function deriveDateFields (collection, requestedFields) {
   if (!_.get(collection, 'metadata.fields')) return []
 
   return collection.metadata.fields.filter(({ type, name }) => {
@@ -13,4 +13,4 @@ function getDateFields (collection, requestedFields) {
   })
 }
 
-module.exports = getDateFields
+module.exports = deriveDateFields

--- a/lib/normalize-query-options/date-fields.js
+++ b/lib/normalize-query-options/date-fields.js
@@ -3,7 +3,7 @@ const _ = require('lodash')
  * @param {object} collection - the GeoJSON object from Koop (with features omitted)
  * @param {*} requestedFields
  */
-function normalizeDateFields (collection, requestedFields) {
+function getDateFields (collection, requestedFields) {
   if (!_.get(collection, 'metadata.fields')) return []
 
   return collection.metadata.fields.filter(({ type, name }) => {
@@ -13,4 +13,4 @@ function normalizeDateFields (collection, requestedFields) {
   })
 }
 
-module.exports = normalizeDateFields
+module.exports = getDateFields

--- a/lib/normalize-query-options/date-fields.js
+++ b/lib/normalize-query-options/date-fields.js
@@ -1,0 +1,16 @@
+const _ = require('lodash')
+/**
+ * @param {object} collection - the GeoJSON object from Koop (with features omitted)
+ * @param {*} requestedFields
+ */
+function normalizeDateFields (collection, requestedFields) {
+  if (!_.get(collection, 'metadata.fields')) return []
+
+  return collection.metadata.fields.filter(({ type, name }) => {
+    return type === 'Date' && (requestedFields === undefined || requestedFields.indexOf(name) > -1)
+  }).map(({ name }) => {
+    return name
+  })
+}
+
+module.exports = normalizeDateFields

--- a/lib/normalize-query-options/index.js
+++ b/lib/normalize-query-options/index.js
@@ -6,7 +6,7 @@ const normalizeAggregates = require('./aggregates')
 const normalizeGroupBy = require('./group-by')
 const normalizeClassification = require('./classification')
 const normalizeCollection = require('./collection')
-const normalizeDateFields = require('./date-fields')
+const getDateFields = require('./date-fields')
 
 const {
   normalizeSpatialPredicate,
@@ -37,7 +37,7 @@ function normalizeQueryOptions (options, features) {
     classification: normalizeClassification(options)
   })
   prepared.offset = normalizeOffset(options)
-  prepared.dateFields = normalizeDateFields(prepared.collection, prepared.fields)
+  prepared.dateFields = getDateFields(prepared.collection, prepared.fields)
 
   return prepared
 }

--- a/lib/normalize-query-options/index.js
+++ b/lib/normalize-query-options/index.js
@@ -6,7 +6,7 @@ const normalizeAggregates = require('./aggregates')
 const normalizeGroupBy = require('./group-by')
 const normalizeClassification = require('./classification')
 const normalizeCollection = require('./collection')
-const getDateFields = require('./date-fields')
+const deriveDateFields = require('./date-fields')
 
 const {
   normalizeSpatialPredicate,
@@ -37,7 +37,7 @@ function normalizeQueryOptions (options, features) {
     classification: normalizeClassification(options)
   })
   prepared.offset = normalizeOffset(options)
-  prepared.dateFields = getDateFields(prepared.collection, prepared.fields)
+  prepared.dateFields = deriveDateFields(prepared.collection, prepared.fields)
 
   return prepared
 }

--- a/lib/normalize-query-options/index.js
+++ b/lib/normalize-query-options/index.js
@@ -6,16 +6,15 @@ const normalizeAggregates = require('./aggregates')
 const normalizeGroupBy = require('./group-by')
 const normalizeClassification = require('./classification')
 const normalizeCollection = require('./collection')
+const normalizeDateFields = require('./date-fields')
 
 const {
-  normalizeDateFields,
   normalizeSpatialPredicate,
   normalizeLimit,
   normalizeGeometry,
   normalizeOffset,
   normalizeProjection,
   normalizeIdField
-
 } = require('./normalizeOptions')
 
 function normalizeQueryOptions (options, features) {

--- a/lib/normalize-query-options/normalizeOptions.js
+++ b/lib/normalize-query-options/normalizeOptions.js
@@ -194,7 +194,6 @@ function normalizeIdField (options, features = []) {
 }
 
 module.exports = {
-  normalizeDateFields,
   normalizeSpatialPredicate,
   normalizeLimit,
   normalizeGeometry,

--- a/lib/normalize-query-options/normalizeOptions.js
+++ b/lib/normalize-query-options/normalizeOptions.js
@@ -13,26 +13,6 @@ const esriPredicates = {
 }
 const wkidLookup = {}
 
-/**
- * Identify Date-type fields and explicitly add to dateFields array if outFields query param contains
- * the date field name or if outFields is a wildcard (when outFields=*, preparedFields === undefined)
- *
- * @param {Object} collection metadata about the data source
- * @param String[] preparedFields - single element string array of delimited field names from "outFields" query param
- */
-function normalizeDateFields (collection, preparedFields) {
-  const dateFields = []
-  if (collection && collection.metadata && collection.metadata.fields) {
-    collection.metadata.fields.forEach((field, i) => {
-      // If field is a Date and was included in requested fields (or requested fields are wildcard) add to array
-      if (field.type === 'Date' && (preparedFields === undefined || preparedFields.indexOf(field.name) > -1)) {
-        dateFields.push(field.name)
-      }
-    })
-  }
-  return dateFields
-}
-
 function normalizeSpatialPredicate (options) {
   const predicate = options.spatialPredicate || options.spatialRel
   return esriPredicates[predicate] || predicate

--- a/test/normalize-query-options/date-fields.spec.js
+++ b/test/normalize-query-options/date-fields.spec.js
@@ -1,31 +1,31 @@
 const test = require('tape')
-const normalizeDateFields = require('../../lib/normalize-query-options/date-fields')
+const getDateFields = require('../../lib/normalize-query-options/date-fields')
 
 test('normalize-query-options, date-fields: undefined metadata', t => {
   t.plan(1)
 
-  const normalized = normalizeDateFields()
+  const normalized = getDateFields()
   t.deepEquals(normalized, [])
 })
 
 test('normalize-query-options, date-fields: undefined metadata.fields', t => {
   t.plan(1)
 
-  const normalized = normalizeDateFields({})
+  const normalized = getDateFields({})
   t.deepEquals(normalized, [])
 })
 
 test('normalize-query-options, date-fields: metadata.fields are empty array', t => {
   t.plan(1)
 
-  const normalized = normalizeDateFields({ fields: [] })
+  const normalized = getDateFields({ fields: [] })
   t.deepEquals(normalized, [])
 })
 
 test('normalize-query-options, date-fields: requestedFields undefined', t => {
   t.plan(1)
 
-  const normalized = normalizeDateFields({
+  const normalized = getDateFields({
     metadata: {
       fields: [
         { name: 'hello', type: 'Date' },
@@ -39,7 +39,7 @@ test('normalize-query-options, date-fields: requestedFields undefined', t => {
 test('normalize-query-options, date-fields: requestedFields defined', t => {
   t.plan(1)
 
-  const normalized = normalizeDateFields({
+  const normalized = getDateFields({
     metadata: {
       fields: [
         { name: 'hello', type: 'Date' },

--- a/test/normalize-query-options/date-fields.spec.js
+++ b/test/normalize-query-options/date-fields.spec.js
@@ -1,0 +1,52 @@
+const test = require('tape')
+const normalizeDateFields = require('../../lib/normalize-query-options/date-fields')
+
+test('normalize-query-options, date-fields: undefined metadata', t => {
+  t.plan(1)
+
+  const normalized = normalizeDateFields()
+  t.deepEquals(normalized, [])
+})
+
+test('normalize-query-options, date-fields: undefined metadata.fields', t => {
+  t.plan(1)
+
+  const normalized = normalizeDateFields({})
+  t.deepEquals(normalized, [])
+})
+
+test('normalize-query-options, date-fields: metadata.fields are empty array', t => {
+  t.plan(1)
+
+  const normalized = normalizeDateFields({ fields: [] })
+  t.deepEquals(normalized, [])
+})
+
+test('normalize-query-options, date-fields: requestedFields undefined', t => {
+  t.plan(1)
+
+  const normalized = normalizeDateFields({
+    metadata: {
+      fields: [
+        { name: 'hello', type: 'Date' },
+        { name: 'world', type: 'String' }
+      ]
+    }
+  })
+  t.deepEquals(normalized, ['hello'])
+})
+
+test('normalize-query-options, date-fields: requestedFields defined', t => {
+  t.plan(1)
+
+  const normalized = normalizeDateFields({
+    metadata: {
+      fields: [
+        { name: 'hello', type: 'Date' },
+        { name: 'world', type: 'String' },
+        { name: 'foo', type: 'String' }
+      ]
+    }
+  }, ['hello', 'foo'])
+  t.deepEquals(normalized, ['hello'])
+})

--- a/test/normalize-query-options/normalizeOptions.js
+++ b/test/normalize-query-options/normalizeOptions.js
@@ -2,7 +2,6 @@ const test = require('tape')
 
 const {
   // TODO: Put these under test
-  // normalizeDateFields,
   // normalizeSpatialPredicate,
   // normalizeLimit,
   // normalizeGeometry,


### PR DESCRIPTION
Move into it's own file and create a full set of tests. Removed "normalize" from function name, as this function doesn't "normalize" anything - instead it derives an array of dateFields from other options.