### PR TITLE
Clean up where-clause generation

### DIFF
--- a/lib/sql-query-builder/index.js
+++ b/lib/sql-query-builder/index.js
@@ -1,13 +1,13 @@
 'use strict'
 const Geometry = require('../geometry')
-const Where = require('./where')
+const createWhereClause = require('./where')
 const createSelectSql = require('./select')
 const Order = require('./order')
 const GroupBy = require('./groupBy')
 
 function create (options) {
   let baseSqlStatement = createSelectSql(options)
-  const where = Where.createClause(options)
+  const where = createWhereClause(options)
   const geomFilter = Geometry.createClause(options)
   const order = Order.createClause(options)
   const groupBy = GroupBy.createClause(options)

--- a/lib/sql-query-builder/where.js
+++ b/lib/sql-query-builder/where.js
@@ -8,6 +8,11 @@ const operatorInversions = {
   '<=': '>',
   '<': '>='
 }
+// RegExp for name-first predicate, e.g "properties->`OBJECTID` = 1234"
+const fieldFirstObjectIdPredicateRegex = /(properties|attributes)->`OBJECTID` (=|<|>|<=|>=) ([0-9]+)/g
+
+// RegExp for value-first predicate, e.g "1234 = properties->`OBJECTID`""
+const valueFirstObjectIdPredicateRegex = /([0-9]+) (=|<|>|<=|>=) (properties|attributes)->`OBJECTID`/g
 
 /**
  * Convert an expression node to its string representation.
@@ -164,47 +169,30 @@ function createClause (options = {}) {
   if (!where) return ''
 
   // AST parsing requires a complete SQL.
-  const whereTree = parser.parse('SELECT * WHERE ' + where).where
-  const whereClauseForGeoJsonQuery = traverse(whereTree, options)
-  return translateObjectIdFragments(whereClauseForGeoJsonQuery, options)
-}
+  const { where: whereTree } = parser.parse(`SELECT * WHERE ${where}`)
+  const whereClause = traverse(whereTree, options)
 
-/**
- * If the WHERE contains fragments with OBJECTID, but the data doesn't contain an OBJECTID field,
- * and no substitution is made with the "idField" property, we must replace these WHERE fragments
- * with use a user-defined function that will calculate the OBJECTID on the fly, do the appropriate
- * comparison, and return the resulting boolean value
- * @param {string} input
- * @param {object} options
- */
-function translateObjectIdFragments (input, options = {}) {
-  let where = input
-  const { idField } = options
-
-  // use a user-defined function to generate an on-the-fly OBJECTID for comparison to the request's value
-  if (where.includes('OBJECTID') && !idField) {
-    // RegExp for name-first predicate, e.g "properties->`OBJECTID` = 1234"
-    const regexOid1st = /(properties|attributes)->`OBJECTID` (=|<|>|<=|>=) ([0-9]+)/g
-
-    // RegExp for value-first predicate, e.g "1234 = properties->`OBJECTID`""
-    const regexOid2nd = /([0-9]+) (=|<|>|<=|>=) (properties|attributes)->`OBJECTID`/g
-
-    where = where.replace(regexOid1st, 'hashedObjectIdComparator($1, geometry, $3, \'$2\')=true').replace(regexOid2nd, replacer)
+  if (shouldReplaceObjectIdPredicates(options)) {
+    return replaceObjectIdPredicates(whereClause)
   }
-  return where
+  return whereClause
 }
 
 /**
- * String replace function receiving regex parameters
- * @param {string} match
- * @param {string} value - first matched group
- * @param {string} operator - second matched group
- * @param {string} parentProperty - third matched group
- * @param {*} offset
- * @param {string} string
+ * if the where clause includes OBJECTID predicate, but the dataset doesn't include an OBJECTID,
+ * assume it is due to ArcGIS clients querying a Koop dataset that had no idField defined and thus created
+ * and OBJECTID field on the fly from the hashed feature. As a result, the OBJECTID predicate must be
+ * replaced by an inline function that (1) hashes the feature and (2) executes the comparison
  */
-function replacer (match, value, operator, parentProperty, offset, string) {
-  return `hashedObjectIdComparator(${parentProperty}, geometry, ${value}, '${operatorInversions[operator]}')=true`
+function shouldReplaceObjectIdPredicates ({ where, idField }) {
+  return where.includes('OBJECTID') && !idField
+}
+
+function replaceObjectIdPredicates (where) {
+  return where.replace(fieldFirstObjectIdPredicateRegex, 'hashedObjectIdComparator($1, geometry, $3, \'$2\')=true')
+    .replace(valueFirstObjectIdPredicateRegex, (match, value, operator, parentProperty, offset, string) => {
+      return `hashedObjectIdComparator(${parentProperty}, geometry, ${value}, '${operatorInversions[operator]}')=true`
+    })
 }
 
 module.exports = { createClause }

--- a/lib/sql-query-builder/where.js
+++ b/lib/sql-query-builder/where.js
@@ -164,7 +164,7 @@ function traverse (node, options) {
  * @param  {string} options winnow options
  * @return {string}         SQL where clause
  */
-function createClause (options = {}) {
+function createWhereClause (options = {}) {
   const { where } = options
   if (!where) return ''
 
@@ -195,4 +195,4 @@ function replaceObjectIdPredicates (where) {
     })
 }
 
-module.exports = { createClause }
+module.exports = createWhereClause

--- a/lib/sql-query-builder/where.js
+++ b/lib/sql-query-builder/where.js
@@ -159,14 +159,14 @@ function traverse (node, options) {
  * @param  {string} options winnow options
  * @return {string}         SQL where clause
  */
-function createClause (options) {
-  options = options || {}
-  if (!options.where) return ''
+function createClause (options = {}) {
+  const { where } = options
+  if (!where) return ''
 
   // AST parsing requires a complete SQL.
-  const whereTree = parser.parse('SELECT * WHERE ' + options.where).where
-  const whereTransform = traverse(whereTree, options)
-  return translateObjectIdFragments(whereTransform, options)
+  const whereTree = parser.parse('SELECT * WHERE ' + where).where
+  const whereClauseForGeoJsonQuery = traverse(whereTree, options)
+  return translateObjectIdFragments(whereClauseForGeoJsonQuery, options)
 }
 
 /**
@@ -181,13 +181,8 @@ function translateObjectIdFragments (input, options = {}) {
   let where = input
   const { idField } = options
 
-  // Check if OBJECTID is one of the GeoJSON properties
-  const metadataObjectIdField = _.get(options, 'collection.metadata.fields', []).find(field => { return field.name === 'OBJECTID' })
-
-  // If the WHERE includes predicates with OBJECTID, but no OBJECTID is defined on the data,
-  // and no `idField` has been assigned, we have to use a user-defined function to generate
-  // an on-the-fly OBJECTID for comparison to the request's value
-  if (where.includes('OBJECTID') && !metadataObjectIdField && !idField) {
+  // use a user-defined function to generate an on-the-fly OBJECTID for comparison to the request's value
+  if (where.includes('OBJECTID') && !idField) {
     // RegExp for name-first predicate, e.g "properties->`OBJECTID` = 1234"
     const regexOid1st = /(properties|attributes)->`OBJECTID` (=|<|>|<=|>=) ([0-9]+)/g
 

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -38,7 +38,7 @@ test('With a field that has been uppercased', t => {
   run('trees', options, 12105, t)
 })
 
-test.only('With the toEsri option', t => {
+test('With the toEsri option', t => {
   const options = {
     toEsri: true,
     where: "Genus like '%Quercus%'"

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -38,7 +38,7 @@ test('With a field that has been uppercased', t => {
   run('trees', options, 12105, t)
 })
 
-test('With the toEsri option', t => {
+test.only('With the toEsri option', t => {
   const options = {
     toEsri: true,
     where: "Genus like '%Quercus%'"

--- a/test/unit/sql-query-builder/where.spec.js
+++ b/test/unit/sql-query-builder/where.spec.js
@@ -1,13 +1,15 @@
 'use strict'
 const test = require('tape')
 const where = require('../../../lib/sql-query-builder/where')
+const normalizeQueryOptions = require('../../../lib/normalize-query-options')
 
 test('Transform a simple equality predicate', t => {
   t.plan(1)
   const options = {
     where: 'foo=\'bar\''
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'properties->`foo` = \'bar\'')
 })
 
@@ -16,7 +18,8 @@ test('Transform a simple but inverse predicate', t => {
   const options = {
     where: '\'bar\'=foo'
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = properties->`foo`')
 })
 
@@ -25,17 +28,19 @@ test('Transform a simple predicate', t => {
   const options = {
     where: '\'bar\'=foo'
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = properties->`foo`')
 })
 
-test('Transform a simple predicate to Esri flavor', t => {
+test('Transform a simple predicate to a form required for Esri JSON', t => {
   t.plan(1)
   const options = {
     where: 'foo=\'bar\'',
     esri: true
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'attributes->`foo` = \'bar\'')
 })
 
@@ -45,7 +50,8 @@ test('Transform a simple but inverse predicate to Esri flavor', t => {
     where: '\'bar\'=foo',
     esri: true
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = attributes->`foo`')
 })
 
@@ -54,7 +60,8 @@ test('Transform a predicate with OBJECTID and no metadata fields to user-defined
   const options = {
     where: 'OBJECTID=1234'
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(properties, geometry, 1234, \'=\')=true')
 })
 
@@ -64,7 +71,8 @@ test('Transform a predicate with OBJECTID and no metadata fields to Esri flavor 
     where: 'OBJECTID=1234',
     esri: true
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(attributes, geometry, 1234, \'=\')=true')
 })
 
@@ -73,7 +81,8 @@ test('Transform an inverse predicate with OBJECTID and no metadata fields to use
   const options = {
     where: '1234>OBJECTID'
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(properties, geometry, 1234, \'<=\')=true')
 })
 
@@ -83,7 +92,8 @@ test('Transform an inverse predicate with OBJECTID and no metadata fields to Esr
     where: '1234>OBJECTID',
     esri: true
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(attributes, geometry, 1234, \'<=\')=true')
 })
 
@@ -97,6 +107,7 @@ test('Transform a predicate with OBJECTID and metadata fields that define the OB
       }
     }
   }
-  const whereFragment = where.createClause(options)
+  const normalizeOpts = normalizeQueryOptions(options)
+  const whereFragment = where.createClause(normalizeOpts)
   t.equals(whereFragment, 'properties->`OBJECTID` = 1234')
 })

--- a/test/unit/sql-query-builder/where.spec.js
+++ b/test/unit/sql-query-builder/where.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 const test = require('tape')
-const where = require('../../../lib/sql-query-builder/where')
+const createWhereClause = require('../../../lib/sql-query-builder/where')
 const normalizeQueryOptions = require('../../../lib/normalize-query-options')
 
 test('Transform a simple equality predicate', t => {
@@ -9,7 +9,7 @@ test('Transform a simple equality predicate', t => {
     where: 'foo=\'bar\''
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'properties->`foo` = \'bar\'')
 })
 
@@ -19,7 +19,7 @@ test('Transform a simple but inverse predicate', t => {
     where: '\'bar\'=foo'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = properties->`foo`')
 })
 
@@ -29,7 +29,7 @@ test('Transform a simple predicate', t => {
     where: '\'bar\'=foo'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = properties->`foo`')
 })
 
@@ -40,7 +40,7 @@ test('Transform a simple predicate to a form required for Esri JSON', t => {
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'attributes->`foo` = \'bar\'')
 })
 
@@ -51,7 +51,7 @@ test('Transform a simple but inverse predicate to Esri flavor', t => {
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = attributes->`foo`')
 })
 
@@ -61,7 +61,7 @@ test('Transform a predicate with OBJECTID and no metadata fields to user-defined
     where: 'OBJECTID=1234'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(properties, geometry, 1234, \'=\')=true')
 })
 
@@ -72,7 +72,7 @@ test('Transform a predicate with OBJECTID and no metadata fields to Esri flavor 
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(attributes, geometry, 1234, \'=\')=true')
 })
 
@@ -82,7 +82,7 @@ test('Transform an inverse predicate with OBJECTID and no metadata fields to use
     where: '1234>OBJECTID'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(properties, geometry, 1234, \'<=\')=true')
 })
 
@@ -93,7 +93,7 @@ test('Transform an inverse predicate with OBJECTID and no metadata fields to Esr
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(attributes, geometry, 1234, \'<=\')=true')
 })
 
@@ -108,6 +108,6 @@ test('Transform a predicate with OBJECTID and metadata fields that define the OB
     }
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = where.createClause(normalizeOpts)
+  const whereFragment = createWhereClause(normalizeOpts)
   t.equals(whereFragment, 'properties->`OBJECTID` = 1234')
 })


### PR DESCRIPTION
Specifically refactors portion of where-clause generation that handles OBJECTID predicates.  Just cleans up code, does not change functionality. Some background: 

1. If a dataset is flagged for translation to Esri JSON and doesn't have metadata that defines an `idField`, Winnow will add an OBJECTID field to each feature's attributes and give it a value based on hashing of the feature.

2. Follow-up queries by the client may include where-clause predicates that include the OBJECTID.  Since the dataset doesn't actually have an OBJECTID field, we need to hash each feature on the fly as the where predicate executes so that we have an OBJECTID to make the comparison.

3.  We do this by replacing the where-clause predicate that targets OBJECTID with an inline function that will make the appropriate comparison.