### PR TITLE
Queries on heroku were broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Farmhash was not working on Heroku, now can gracefully fallback on systems without a working Farmhash binary.
+
 ## [2.0.1] - 09-10-2020
 ### Fixed
 * Version bump for flopped release and publish

--- a/lib/alasql.js
+++ b/lib/alasql.js
@@ -18,8 +18,8 @@ const reducePrecision = require('./geometry/reduce-precision')
 let hashFunction
 try {
   hashFunction = require('farmhash').hash32
-  //testing the require isnt enough. on heroku the binary for farmhash does not work and queries totally break.
-  hashFunction("test") 
+  // testing the require isnt enough. on heroku the binary for farmhash does not work and queries totally break.
+  hashFunction('test')
 } catch (e) {
   hashFunction = require('string-hash')
 }

--- a/lib/alasql.js
+++ b/lib/alasql.js
@@ -18,6 +18,8 @@ const reducePrecision = require('./geometry/reduce-precision')
 let hashFunction
 try {
   hashFunction = require('farmhash').hash32
+  //testing the require isnt enough. on heroku the binary for farmhash does not work and queries totally break.
+  hashFunction("test") 
 } catch (e) {
   hashFunction = require('string-hash')
 }


### PR DESCRIPTION
On heroku, queries were broken by farmhash's binary not loading correctly and the try catch not finding it.
I added a line to test farmhash and on systems where the issue exists, it should instead use the other hashing algo, which works correctly.
