### PR TITLE
Consolidate where-clause generation.

### DIFF
--- a/lib/geometry/index.js
+++ b/lib/geometry/index.js
@@ -1,7 +1,0 @@
-function createClause (options) {
-  if (!options.geometry) return
-  const spatialPredicate = options.spatialPredicate || 'ST_Intersects'
-  return `${spatialPredicate}(geometry, ?)`
-}
-
-module.exports = { createClause }

--- a/lib/sql-query-builder/index.js
+++ b/lib/sql-query-builder/index.js
@@ -1,5 +1,3 @@
-'use strict'
-const Geometry = require('../geometry')
 const createWhereClause = require('./where')
 const createSelectSql = require('./select')
 const Order = require('./order')
@@ -7,14 +5,11 @@ const GroupBy = require('./groupBy')
 
 function create (options) {
   let baseSqlStatement = createSelectSql(options)
-  const where = createWhereClause(options)
-  const geomFilter = Geometry.createClause(options)
+  const whereClause = createWhereClause(options)
   const order = Order.createClause(options)
   const groupBy = GroupBy.createClause(options)
-  if (options.where || options.geometry) baseSqlStatement += ' WHERE '
-  if (options.where) baseSqlStatement += where
-  if (options.geometry && !where) baseSqlStatement += geomFilter
-  if (options.geometry && where) baseSqlStatement += ` AND ${geomFilter}`
+  baseSqlStatement = `${baseSqlStatement}${whereClause}`
+
   // if (options.aggregates) return query
   if (options.groupBy && groupBy) baseSqlStatement += groupBy
   if (options.order || options.orderByFields) baseSqlStatement += order

--- a/lib/sql-query-builder/where/geometry-predicate.js
+++ b/lib/sql-query-builder/where/geometry-predicate.js
@@ -1,4 +1,5 @@
 module.exports = function ({ geometry, spatialPredicate = 'ST_Intersects' } = {}) {
   if (!geometry) return
+  // The "?" in the string below is a SQL query parameter.  When it is execute, a supplied value is used in its place
   return `${spatialPredicate}(geometry, ?)`
 }

--- a/lib/sql-query-builder/where/geometry-predicate.js
+++ b/lib/sql-query-builder/where/geometry-predicate.js
@@ -1,0 +1,4 @@
+module.exports = function ({ geometry, spatialPredicate = 'ST_Intersects' } = {}) {
+  if (!geometry) return
+  return `${spatialPredicate}(geometry, ?)`
+}

--- a/lib/sql-query-builder/where/index.js
+++ b/lib/sql-query-builder/where/index.js
@@ -1,0 +1,21 @@
+const translateSqlWhere = require('./translate-sql-where')
+const createGeometryPredicate = require('./geometry-predicate')
+
+function createWhereClause (options = {}) {
+  const { where, geometry } = options
+  if (!where && !geometry) return ''
+
+  const fragments = []
+
+  if (where) {
+    fragments.push(translateSqlWhere(options))
+  }
+
+  if (geometry) {
+    fragments.push(createGeometryPredicate(options))
+  }
+
+  return ` WHERE ${fragments.join(' AND ')}`
+}
+
+module.exports = createWhereClause

--- a/lib/sql-query-builder/where/translate-sql-where.js
+++ b/lib/sql-query-builder/where/translate-sql-where.js
@@ -159,16 +159,8 @@ function traverse (node, options) {
   }
 }
 
-/**
- * Creates a viable SQL where clause from a passed in SQL (from a url "where" param)
- * @param  {string} options winnow options
- * @return {string}         SQL where clause
- */
-function createWhereClause (options = {}) {
+function translateSqlWhere (options) {
   const { where } = options
-  if (!where) return ''
-
-  // AST parsing requires a complete SQL.
   const { where: whereTree } = parser.parse(`SELECT * WHERE ${where}`)
   const whereClause = traverse(whereTree, options)
 
@@ -195,4 +187,4 @@ function replaceObjectIdPredicates (where) {
     })
 }
 
-module.exports = createWhereClause
+module.exports = translateSqlWhere

--- a/test/unit/sql-query-builder/where/geometry-predicate.spec.js
+++ b/test/unit/sql-query-builder/where/geometry-predicate.spec.js
@@ -1,0 +1,30 @@
+const test = require('tape')
+const createGeometryPredicate = require('../../../../lib/sql-query-builder/where/geometry-predicate')
+const normalizeQueryOptions = require('../../../../lib/normalize-query-options')
+
+test('geometryPredicate: returns undefined if no options', t => {
+  t.plan(1)
+  const geometryPredicate = createGeometryPredicate()
+  t.equals(geometryPredicate, undefined)
+})
+
+test('geometryPredicate: returns undefined if empty options', t => {
+  t.plan(1)
+  const options = normalizeQueryOptions({})
+  const geometryPredicate = createGeometryPredicate(options)
+  t.equals(geometryPredicate, undefined)
+})
+
+test('geometryPredicate: returns default geometry function if geometry filter option is defined', t => {
+  t.plan(1)
+  const options = normalizeQueryOptions({ geometry: [0, 0, 0, 0] })
+  const geometryPredicate = createGeometryPredicate(options)
+  t.equals(geometryPredicate, 'ST_Intersects(geometry, ?)')
+})
+
+test('geometryPredicate: returns request geometry function if geometry filter and spatial-predicate options are defined', t => {
+  t.plan(1)
+  const options = normalizeQueryOptions({ geometry: [0, 0, 0, 0], spatialPredicate: 'ST_Contains' })
+  const geometryPredicate = createGeometryPredicate(options)
+  t.equals(geometryPredicate, 'ST_Contains(geometry, ?)')
+})

--- a/test/unit/sql-query-builder/where/index.spec.js
+++ b/test/unit/sql-query-builder/where/index.spec.js
@@ -1,0 +1,39 @@
+const test = require('tape')
+const createWhereClause = require('../../../../lib/sql-query-builder/where')
+
+test('createWhereClause: returns empty string if no options', t => {
+  t.plan(1)
+  const whereClause = createWhereClause()
+  t.equals(whereClause, '')
+})
+
+test('createWhereClause: returns empty string if empty options', t => {
+  t.plan(1)
+  const whereClause = createWhereClause({})
+  t.equals(whereClause, '')
+})
+
+test('createWhereClause: returns where clause with translated SQL where', t => {
+  t.plan(1)
+  const whereClause = createWhereClause({
+    where: 'color=\'red\''
+  })
+  t.equals(whereClause, ' WHERE properties->`color` = \'red\'')
+})
+
+test('createWhereClause: returns where clause with geometry predicate', t => {
+  t.plan(1)
+  const whereClause = createWhereClause({
+    geometry: [0, 0, 0, 0]
+  })
+  t.equals(whereClause, ' WHERE ST_Intersects(geometry, ?)')
+})
+
+test('createWhereClause: returns where clause with translated sql-where and geometry predicate', t => {
+  t.plan(1)
+  const whereClause = createWhereClause({
+    geometry: [0, 0, 0, 0],
+    where: 'color=\'red\''
+  })
+  t.equals(whereClause, ' WHERE properties->`color` = \'red\' AND ST_Intersects(geometry, ?)')
+})

--- a/test/unit/sql-query-builder/where/translate-sql-where.spec.js
+++ b/test/unit/sql-query-builder/where/translate-sql-where.spec.js
@@ -1,103 +1,102 @@
-'use strict'
 const test = require('tape')
-const createWhereClause = require('../../../lib/sql-query-builder/where')
-const normalizeQueryOptions = require('../../../lib/normalize-query-options')
+const translateSqlWhere = require('../../../../lib/sql-query-builder/where/translate-sql-where')
+const normalizeQueryOptions = require('../../../../lib/normalize-query-options')
 
-test('Transform a simple equality predicate', t => {
+test('translateSqlWhere: transform a simple equality predicate', t => {
   t.plan(1)
   const options = {
     where: 'foo=\'bar\''
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'properties->`foo` = \'bar\'')
 })
 
-test('Transform a simple but inverse predicate', t => {
+test('translateSqlWhere: transform a simple but inverse predicate', t => {
   t.plan(1)
   const options = {
     where: '\'bar\'=foo'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = properties->`foo`')
 })
 
-test('Transform a simple predicate', t => {
+test('translateSqlWhere: transform a simple predicate', t => {
   t.plan(1)
   const options = {
     where: '\'bar\'=foo'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = properties->`foo`')
 })
 
-test('Transform a simple predicate to a form required for Esri JSON', t => {
+test('translateSqlWhere: transform a simple predicate to a form required for Esri JSON', t => {
   t.plan(1)
   const options = {
     where: 'foo=\'bar\'',
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'attributes->`foo` = \'bar\'')
 })
 
-test('Transform a simple but inverse predicate to Esri flavor', t => {
+test('translateSqlWhere: transform a simple but inverse predicate to Esri flavor', t => {
   t.plan(1)
   const options = {
     where: '\'bar\'=foo',
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, '\'bar\' = attributes->`foo`')
 })
 
-test('Transform a predicate with OBJECTID and no metadata fields to user-defined function', t => {
+test('translateSqlWhere: transform a predicate with OBJECTID and no metadata fields to user-defined function', t => {
   t.plan(1)
   const options = {
     where: 'OBJECTID=1234'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(properties, geometry, 1234, \'=\')=true')
 })
 
-test('Transform a predicate with OBJECTID and no metadata fields to Esri flavor with user-defined function', t => {
+test('translateSqlWhere: transform a predicate with OBJECTID and no metadata fields to Esri flavor with user-defined function', t => {
   t.plan(1)
   const options = {
     where: 'OBJECTID=1234',
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(attributes, geometry, 1234, \'=\')=true')
 })
 
-test('Transform an inverse predicate with OBJECTID and no metadata fields to user-defined function', t => {
+test('translateSqlWhere: transform an inverse predicate with OBJECTID and no metadata fields to user-defined function', t => {
   t.plan(1)
   const options = {
     where: '1234>OBJECTID'
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(properties, geometry, 1234, \'<=\')=true')
 })
 
-test('Transform an inverse predicate with OBJECTID and no metadata fields to Esri flavor with user-defined function', t => {
+test('translateSqlWhere: transform an inverse predicate with OBJECTID and no metadata fields to Esri flavor with user-defined function', t => {
   t.plan(1)
   const options = {
     where: '1234>OBJECTID',
     esri: true
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'hashedObjectIdComparator(attributes, geometry, 1234, \'<=\')=true')
 })
 
-test('Transform a predicate with OBJECTID and metadata fields that define the OBJECTID', t => {
+test('translateSqlWhere: transform a predicate with OBJECTID and metadata fields that define the OBJECTID', t => {
   t.plan(1)
   const options = {
     where: 'OBJECTID=1234',
@@ -108,6 +107,6 @@ test('Transform a predicate with OBJECTID and metadata fields that define the OB
     }
   }
   const normalizeOpts = normalizeQueryOptions(options)
-  const whereFragment = createWhereClause(normalizeOpts)
+  const whereFragment = translateSqlWhere(normalizeOpts)
   t.equals(whereFragment, 'properties->`OBJECTID` = 1234')
 })


### PR DESCRIPTION
The geometry filter is part of the final where-clause.  As such, this PR reorganizes files, and consolidates the translation of the where and geometry options, which cleans up the higher level SQL generation function.  Unit tests added.