### PR TITLE
Handle escaped single quotes in where parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 ### Fixed
 * Fixes a bug in the "envelope-intersects" operation.  Research indicates that the Esri envelope-intersects operation should check that an "Envelope of Query Geometry Intersects Envelope of Target Geometry" (see [here](http://resources.esri.com/help/9.3/ArcGISDesktop/ArcObjects/esriGeoDatabase/esriSpatialRelEnum.htm)).
+* Handle sql-escape single quotes in where parameter, e.g. `where=food=bar''s`
 
 ### Added
 * Adds support for the `!=` operator in the hashed OBJECTID comparison.

--- a/lib/sql-query-builder/where/translate-sql-where.js
+++ b/lib/sql-query-builder/where/translate-sql-where.js
@@ -109,7 +109,8 @@ function handleValue (node, options) {
   }
 
   if (typeof value === 'string') {
-    value = `'${value}'`
+    // single quotes in the value will break alasql queries. They must be escaped with ''.
+    value = `'${value.replace('\'', '\'\'')}'`
   }
 
   return value
@@ -161,7 +162,7 @@ function traverse (node, options) {
 
 function translateSqlWhere (options) {
   const { where } = options
-  const { where: whereTree } = parser.parse(`SELECT * WHERE ${where}`)
+  const whereTree = parseWhereToTree(where)
   const whereClause = traverse(whereTree, options)
 
   if (shouldReplaceObjectIdPredicates(options)) {
@@ -170,6 +171,14 @@ function translateSqlWhere (options) {
   return whereClause
 }
 
+function parseWhereToTree (where) {
+  // SQL uses '' for escaping a single quote, but the flora-sql-parser uses \\'.  Replace here.
+  const escapedWhere = where.replace('\'\'', '\\\'')
+
+  const { where: whereTree } = parser.parse(`SELECT * WHERE ${escapedWhere}`)
+
+  return whereTree
+}
 /**
  * if the where clause includes OBJECTID predicate, but the dataset doesn't include an OBJECTID,
  * assume it is due to ArcGIS clients querying a Koop dataset that had no idField defined and thus created

--- a/lib/sql-query-builder/where/translate-sql-where.js
+++ b/lib/sql-query-builder/where/translate-sql-where.js
@@ -110,7 +110,7 @@ function handleValue (node, options) {
 
   if (typeof value === 'string') {
     // single quotes in the value will break alasql queries. They must be escaped with ''.
-    value = `'${value.replace('\'', '\'\'')}'`
+    value = `'${value.replace(/'/g, '\'\'')}'`
   }
 
   return value
@@ -173,7 +173,7 @@ function translateSqlWhere (options) {
 
 function parseWhereToTree (where) {
   // SQL uses '' for escaping a single quote, but the flora-sql-parser uses \\'.  Replace here.
-  const escapedWhere = where.replace('\'\'', '\\\'')
+  const escapedWhere = where.replace(/''/g, '\\\'')
 
   const { where: whereTree } = parser.parse(`SELECT * WHERE ${escapedWhere}`)
 

--- a/lib/sql-query-builder/where/translate-sql-where.js
+++ b/lib/sql-query-builder/where/translate-sql-where.js
@@ -179,6 +179,7 @@ function parseWhereToTree (where) {
 
   return whereTree
 }
+
 /**
  * if the where clause includes OBJECTID predicate, but the dataset doesn't include an OBJECTID,
  * assume it is due to ArcGIS clients querying a Koop dataset that had no idField defined and thus created

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -520,7 +520,7 @@ test('with a between query', t => {
   run('trees', options, 2, t)
 })
 
-test.only('with escaped single quote in query', t => {
+test('with escaped single quote in query', t => {
   const options = {
     where: "Street_Name = 'GRAND''S STREET''S'"
   }

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -520,6 +520,13 @@ test('with a between query', t => {
   run('trees', options, 2, t)
 })
 
+test('with escaped single quote in query', t => {
+  const options = {
+    where: "Street_Name = 'GRAND''S'"
+  }
+  run('trees', options, 1, t)
+})
+
 test('with a OBJECTID query on data that requires dynamic OBJECTID generation', t => {
   t.plan(1)
   const options = {

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -520,9 +520,9 @@ test('with a between query', t => {
   run('trees', options, 2, t)
 })
 
-test('with escaped single quote in query', t => {
+test.only('with escaped single quote in query', t => {
   const options = {
-    where: "Street_Name = 'GRAND''S'"
+    where: "Street_Name = 'GRAND''S STREET''S'"
   }
   run('trees', options, 1, t)
 })

--- a/test/integration/fixtures/trees.json
+++ b/test/integration/fixtures/trees.json
@@ -16,7 +16,7 @@
                 "Species": "GRANDIFLORA",
                 "House_Number": 505,
                 "Street_Direction": "S",
-                "Street_Name": "GRAND",
+                "Street_Name": "GRAND'S",
                 "Street_Type": "AVE",
                 "Street_Suffix": null,
                 "Trunk_Diameter": 13,

--- a/test/integration/fixtures/trees.json
+++ b/test/integration/fixtures/trees.json
@@ -16,7 +16,7 @@
                 "Species": "GRANDIFLORA",
                 "House_Number": 505,
                 "Street_Direction": "S",
-                "Street_Name": "GRAND'S",
+                "Street_Name": "GRAND'S STREET'S",
                 "Street_Type": "AVE",
                 "Street_Suffix": null,
                 "Trunk_Diameter": 13,


### PR DESCRIPTION
ArcGIS clients escape single quotes in where clauses with sql-style `''`.  But this double single quote breaks filtering because the SQL parser doesn't handle `''`.  To fix this until we can get a PR into flora-sql-parser, this PR implements:

1. Replace any `''` found in the `where` with a `\'` which is the escape used by flora-sql-parser. Example:
`where=food='bar''s'` becomes `where=food='bar\'s'`

After parsing the `where` with flora-sql-parser, value of this node of the AST is `bar's`.  Note that parsing removes the escape from the single quote!

This result is problematic for winnow because we wrap values in single quotes to prepare them for the alasql query statement.  So the query statement ends up looking like `SELECT * FROM WHERE food = 'bar's'`.  This breaks the alasql query because the single quote is no longer escaped!

2. So the solution is to add back the SQL-style single quote escaping before passing on the value to alasql.  Any single quotes are replaced with `''`.  Doing so generates a valid SQL like `SELECT * FROM WHERE food = 'bar''s'`