### PR TITLE
Output CRS deference fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* When no reprojection, output CRS is assigned same value as input CRS
+
 ## [2.2.1] - 12-14-2020
 ### Fixed
 * Handling of null geometry in the to-Esri geometry transform

--- a/lib/normalize-query-options/helpers/get-collection-crs.js
+++ b/lib/normalize-query-options/helpers/get-collection-crs.js
@@ -1,0 +1,18 @@
+const _ = require('lodash')
+const OGC_WGS84 = 'ogc:1.3:crs84'
+
+function getCollectionCrs (collection) {
+  const collectionCrs = _.get(collection, 'crs.properties.name')
+  if (!collectionCrs) return
+
+  const crs = collectionCrs.toLowerCase().replace(/urn:ogc:def:crs:/, '')
+  if (crs === OGC_WGS84) return
+
+  const crsRegex = /(?<authority>[a-z]+)(::|:)(?<srid>.+)/
+  const result = crsRegex.exec(crs)
+  if (!result) return
+  const { groups: { srid } } = result
+  return srid
+}
+
+module.exports = getCollectionCrs

--- a/lib/normalize-query-options/helpers/index.js
+++ b/lib/normalize-query-options/helpers/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   normalizeArray: require('./normalize-array'),
-  detectEsriFieldType: require('./detect-esri-field-type')
+  detectEsriFieldType: require('./detect-esri-field-type'),
+  getCollectionCrs: require('./get-collection-crs')
 }

--- a/lib/normalize-query-options/output-data-spatial-reference.js
+++ b/lib/normalize-query-options/output-data-spatial-reference.js
@@ -1,4 +1,5 @@
 const normalizeSpatialReference = require('./spatial-reference')
+const { getCollectionCrs } = require('./helpers')
 const logWarning = process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress'
 
 function normalizeOutputDataSpatialReference (options = {}) {
@@ -9,15 +10,16 @@ function normalizeOutputDataSpatialReference (options = {}) {
     outputCrs,
     outSR,
     inputCrs,
-    sourceSR
+    sourceSR,
+    collection
   } = options
 
   // if no output spatial reference set (outputCrs, projection, srsname, srsName, outSR), assume output will be same as input (inputCrs, sourceSR)
-  const outputSpatialReference = outputCrs || projection || srsname || srsName || outSR || inputCrs || sourceSR || 4326
+  const outputSpatialReference = outputCrs || projection || srsname || srsName || outSR || inputCrs || sourceSR || getCollectionCrs(collection) || 4326
 
   const spatialReference = normalizeSpatialReference(outputSpatialReference)
 
-  if (logWarning) console.log(`WARNING: spatial reference "${outputSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`)
+  if (!spatialReference && logWarning) console.log(`WARNING: spatial reference "${outputSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`)
 
   return spatialReference || { wkid: 4326 }
 }

--- a/lib/normalize-query-options/source-data-spatial-reference.js
+++ b/lib/normalize-query-options/source-data-spatial-reference.js
@@ -1,7 +1,6 @@
-const _ = require('lodash')
 const normalizeSpatialReference = require('./spatial-reference')
 const logWarning = process.env.NODE_ENV !== 'production' && process.env.KOOP_WARNINGS !== 'suppress'
-const OGC_WGS84 = 'ogc:1.3:crs84'
+const { getCollectionCrs } = require('./helpers')
 
 function normalizeSourceDataSpatialReference ({ inputCrs, sourceSR, collection } = {}) {
   const sourceDataSpatialReference = inputCrs || sourceSR || getCollectionCrs(collection)
@@ -9,22 +8,9 @@ function normalizeSourceDataSpatialReference ({ inputCrs, sourceSR, collection }
 
   const spatialReference = normalizeSpatialReference(sourceDataSpatialReference)
 
-  if (logWarning) console.log(`WARNING: spatial reference "${sourceDataSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`)
+  if (!spatialReference && logWarning) console.log(`WARNING: spatial reference "${sourceDataSpatialReference}" could not be normalized. Defaulting to EPSG:4326.`)
 
   return spatialReference || { wkid: 4326 }
 }
 
-function getCollectionCrs (collection) {
-  const collectionCrs = _.get(collection, 'crs.properties.name')
-  if (!collectionCrs) return
-
-  const crs = collectionCrs.toLowerCase().replace(/urn:ogc:def:crs:/, '')
-  if (crs === OGC_WGS84) return
-
-  const crsRegex = /(?<authority>[a-z]+)(::|:)(?<srid>.+)/
-  const result = crsRegex.exec(crs)
-  if (!result) return
-  const { groups: { srid } } = result
-  return srid
-}
 module.exports = normalizeSourceDataSpatialReference

--- a/test/unit/normalize-query-options/helpers/get-collection-crs.spec.js
+++ b/test/unit/normalize-query-options/helpers/get-collection-crs.spec.js
@@ -1,0 +1,38 @@
+const test = require('tape')
+const { getCollectionCrs } = require('../../../../lib/normalize-query-options/helpers')
+
+test('getCollectionCrs: no collection', t => {
+  t.plan(1)
+  const crs = getCollectionCrs()
+  t.equals(crs, undefined)
+})
+
+test('getCollectionCrs: no crs', t => {
+  t.plan(1)
+  const crs = getCollectionCrs({})
+  t.equals(crs, undefined)
+})
+
+test('getCollectionCrs: no crs object', t => {
+  t.plan(1)
+  const crs = getCollectionCrs({ crs: {} })
+  t.equals(crs, undefined)
+})
+
+test('getCollectionCrs: bad crs definition', t => {
+  t.plan(1)
+  const crs = getCollectionCrs({ crs: { properties: { name: 'foodbar' } } })
+  t.equals(crs, undefined)
+})
+
+test('getCollectionCrs: WGS84 definition', t => {
+  t.plan(1)
+  const crs = getCollectionCrs({ crs: { properties: { name: 'urn:ogc:def:crs:ogc:1.3:crs84' } } })
+  t.equals(crs, undefined)
+})
+
+test('getCollectionCrs: non-WGS84 definition', t => {
+  t.plan(1)
+  const crs = getCollectionCrs({ crs: { properties: { name: 'urn:ogc:def:crs:EPSG::2285' } } })
+  t.equals(crs, '2285')
+})

--- a/test/unit/normalize-query-options/output-data-spatial-reference.spec.js
+++ b/test/unit/normalize-query-options/output-data-spatial-reference.spec.js
@@ -56,6 +56,38 @@ test('normalize-query-options, output-data-spatial-reference: defer to outSR opt
   t.equal(wkt, 'PROJCS["NAD_1983_StatePlane_California_III_FIPS_0403_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",6561666.666666666],PARAMETER["False_Northing",1640416.666666667],PARAMETER["Central_Meridian",-120.5],PARAMETER["Standard_Parallel_1",37.06666666666667],PARAMETER["Standard_Parallel_2",38.43333333333333],PARAMETER["Latitude_Of_Origin",36.5],UNIT["Foot_US",0.3048006096012192]]')
 })
 
+test('normalize-query-options, output-data-spatial-reference: defer to inputCrs option', t => {
+  t.plan(2)
+  const options = {
+    inputCrs: 2227
+  }
+  const { wkid, wkt } = normalizeOutputDataSpatialReference(options)
+  t.equal(wkid, 2227)
+  t.equal(wkt, 'PROJCS["NAD_1983_StatePlane_California_III_FIPS_0403_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",6561666.666666666],PARAMETER["False_Northing",1640416.666666667],PARAMETER["Central_Meridian",-120.5],PARAMETER["Standard_Parallel_1",37.06666666666667],PARAMETER["Standard_Parallel_2",38.43333333333333],PARAMETER["Latitude_Of_Origin",36.5],UNIT["Foot_US",0.3048006096012192]]')
+})
+
+test('normalize-query-options, output-data-spatial-reference: defer to sourceSR option', t => {
+  t.plan(2)
+  const options = {
+    sourceSR: 2227
+  }
+  const { wkid, wkt } = normalizeOutputDataSpatialReference(options)
+  t.equal(wkid, 2227)
+  t.equal(wkt, 'PROJCS["NAD_1983_StatePlane_California_III_FIPS_0403_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",6561666.666666666],PARAMETER["False_Northing",1640416.666666667],PARAMETER["Central_Meridian",-120.5],PARAMETER["Standard_Parallel_1",37.06666666666667],PARAMETER["Standard_Parallel_2",38.43333333333333],PARAMETER["Latitude_Of_Origin",36.5],UNIT["Foot_US",0.3048006096012192]]')
+})
+
+test('normalize-query-options, output-data-spatial-reference: defer to collection.crs option', t => {
+  t.plan(2)
+  const options = {
+    collection: {
+      crs: { properties: { name: 'urn:ogc:def:crs:EPSG:2227' } }
+    }
+  }
+  const { wkid, wkt } = normalizeOutputDataSpatialReference(options)
+  t.equal(wkid, 2227)
+  t.equal(wkt, 'PROJCS["NAD_1983_StatePlane_California_III_FIPS_0403_Feet",GEOGCS["GCS_North_American_1983",DATUM["D_North_American_1983",SPHEROID["GRS_1980",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Lambert_Conformal_Conic"],PARAMETER["False_Easting",6561666.666666666],PARAMETER["False_Northing",1640416.666666667],PARAMETER["Central_Meridian",-120.5],PARAMETER["Standard_Parallel_1",37.06666666666667],PARAMETER["Standard_Parallel_2",38.43333333333333],PARAMETER["Latitude_Of_Origin",36.5],UNIT["Foot_US",0.3048006096012192]]')
+})
+
 test('normalize-query-options, output-data-spatial-reference: bad input', t => {
   t.plan(1)
   const options = {


### PR DESCRIPTION
When no reprojection, output CRS should be assigned same value as input CRS.  If neither `inputCrs` or `sourceSR` options are defined, Winnow should look for a CRS definition on the collection.