### PR TITLE
Fix breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Refactored class break generator
+
 ## [2.2.2] - 12-16-2020
 ### Fixed
 * When no reprojection, output CRS is assigned same value as input CRS

--- a/lib/calculate-class-breaks/filter-and-validate-classification-features.js
+++ b/lib/calculate-class-breaks/filter-and-validate-classification-features.js
@@ -1,0 +1,22 @@
+const _ = require('lodash')
+
+module.exports = function filterAndValidateClassificationFeatures (features, classificationField) {
+  return features.filter(feature => {
+    return !shouldSkipFeature({ feature, classificationField })
+  }).map(feature => {
+    validateClassificationValue(feature, classificationField)
+    return Number(feature.properties[classificationField])
+  })
+}
+
+function validateClassificationValue ({ properties }, classificationField) {
+  const value = properties[classificationField]
+  if (_.isNaN(Number(value))) {
+    throw new TypeError(`Cannot use non-numeric classificationField, ${classificationField}: "${value}"`)
+  }
+}
+
+function shouldSkipFeature ({ feature: { properties }, classificationField }) {
+  const value = properties[classificationField]
+  return value === undefined || value === null
+}

--- a/lib/calculate-class-breaks/normalize-classification-values.js
+++ b/lib/calculate-class-breaks/normalize-classification-values.js
@@ -1,4 +1,5 @@
 const _ = require('lodash')
+const filterAndValidateClassificationFeatures = require('./filter-and-validate-classification-features')
 
 function normalizeClassBreaks (features, classification) {
   const { normType: type } = classification
@@ -48,7 +49,7 @@ function normalizeByField (features, { field: classificationField, normField: no
 }
 
 function normalizeByLog (features, { field: classificationField }) {
-  const values = filterAndValidate(features, classificationField).map(value => {
+  const values = filterAndValidateClassificationFeatures(features, classificationField).map(value => {
     return value <= 0 ? 0 : Math.log10(value)
   })
 
@@ -58,28 +59,14 @@ function normalizeByLog (features, { field: classificationField }) {
   return values
 }
 
-function filterAndValidate (features, classificationField) {
-  return features.filter(feature => {
-    return !shouldSkipFeature({ feature, classificationField })
-  }).map(feature => {
-    validateClassificationValue(feature, classificationField)
-    return feature.properties[classificationField]
-  })
-}
-
 function normalizeByPercent (features, { field: classificationField }) {
-  const values = filterAndValidate(features, classificationField)
+  const values = filterAndValidateClassificationFeatures(features, classificationField)
 
   const valueTotal = values.reduce((sum, value) => { return sum + value }, 0)
 
   if (valueTotal <= 0) throw new Error(`Cannot normalize by percent because value total is not greater than 0: ${valueTotal}`)
 
   return values.map(value => { return (value / valueTotal) * 100 })
-}
-
-function shouldSkipFeature ({ feature: { properties }, classificationField }) {
-  const value = properties[classificationField]
-  return value === undefined || value === null
 }
 
 function shouldSkipFeatureForFieldNormalization ({ feature: { properties }, classificationField, normalizationField }) {
@@ -100,10 +87,4 @@ function validateNormalizationValues ({ feature: { properties }, classificationF
   }
 }
 
-function validateClassificationValue ({ properties }, classificationField) {
-  const value = properties[classificationField]
-  if (!_.isNumber(value)) {
-    throw new TypeError(`Cannot use non-numeric classificationField, ${classificationField}: "${value}"`)
-  }
-}
 module.exports = normalizeClassBreaks

--- a/lib/calculate-class-breaks/normalize-classification-values.js
+++ b/lib/calculate-class-breaks/normalize-classification-values.js
@@ -50,7 +50,11 @@ function normalizeByField (features, { field: classificationField, normField: no
 
 function normalizeByLog (features, { field: classificationField }) {
   const values = filterAndValidateClassificationFeatures(features, classificationField).map(value => {
-    return value <= 0 ? 0 : Math.log10(value)
+    if (value <= 0) {
+      return 0
+    }
+    const logValue = Math.log10(value)
+    return logValue < 0 ? 0 : logValue
   })
 
   if (!values || values.length === 0) {

--- a/test/unit/calculate-class-breaks/filter-and-validate-classification-features.spec.js
+++ b/test/unit/calculate-class-breaks/filter-and-validate-classification-features.spec.js
@@ -1,7 +1,7 @@
 const test = require('tape')
 const filterAndValidateClassificationValues = require('../../../lib/calculate-class-breaks/filter-and-validate-classification-features')
 
-test('filterAndValidateClassificationValues: invalid std dev interval', spec => {
+test('filterAndValidateClassificationValues: success', spec => {
   const features = [
     { properties: { rain: 0.1 } },
     { properties: { rain: '0.1' } },
@@ -9,6 +9,23 @@ test('filterAndValidateClassificationValues: invalid std dev interval', spec => 
     { properties: { } }
   ]
   const result = filterAndValidateClassificationValues(features, 'rain')
-  spec.deepEquals(result, [5.866775, 16.133225])
+  spec.deepEquals(result, [0.1, 0.1, 0])
+  spec.end()
+})
+
+test('filterAndValidateClassificationValues: should throw error', spec => {
+  const features = [
+    { properties: { rain: 0.1 } },
+    { properties: { rain: 'foo' } },
+    { properties: { rain: 0 } },
+    { properties: { } }
+  ]
+
+  try {
+    filterAndValidateClassificationValues(features, 'rain')
+    spec.fail('should throw error')
+  } catch (error) {
+    spec.equals(error.message, 'Cannot use non-numeric classificationField, rain: "foo"')
+  }
   spec.end()
 })

--- a/test/unit/calculate-class-breaks/filter-and-validate-classification-features.spec.js
+++ b/test/unit/calculate-class-breaks/filter-and-validate-classification-features.spec.js
@@ -1,0 +1,14 @@
+const test = require('tape')
+const filterAndValidateClassificationValues = require('../../../lib/calculate-class-breaks/filter-and-validate-classification-features')
+
+test('filterAndValidateClassificationValues: invalid std dev interval', spec => {
+  const features = [
+    { properties: { rain: 0.1 } },
+    { properties: { rain: '0.1' } },
+    { properties: { rain: 0 } },
+    { properties: { } }
+  ]
+  const result = filterAndValidateClassificationValues(features, 'rain')
+  spec.deepEquals(result, [5.866775, 16.133225])
+  spec.end()
+})


### PR DESCRIPTION
The refactor for class break generation had a few breaking changes:

* Classification fields that are stringified numbers should not be rejected; rather, they should be cast to numbers
* Log normalization function that produces values < 0 should return `0`.

Note that I don't necessarily agree with the logic here, just maintaining the legacy code so we don't introduce a breaking change.  This logic should be revisited and perhaps changed - it may make more sense to move class break generation out of winnow and into FeatureServer as this seems like code that is specifically for the generateRenderer route.