### PR TITLE
Fix check for warning log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Warning log for missing geometry filter spatial referenc
+
 ## [2.2.3] - 01-25-2021
 ### Changed
 * Refactored class break generation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-* Warning log for missing geometry filter spatial referenc
+* Warning log for missing geometry filter spatial reference
 
 ## [2.2.3] - 01-25-2021
 ### Changed

--- a/lib/normalize-query-options/geometry-filter-spatial-reference.js
+++ b/lib/normalize-query-options/geometry-filter-spatial-reference.js
@@ -15,7 +15,7 @@ function normalizeGeometryFilterSpatialReference (options = {}) {
 
   const spatialReference = normalizeSpatialReference(geometryEnvelopeSpatialReference || options.inSR)
 
-  if (logWarning) console.log('WARNING: geometry filter spatial reference unknown. Defaulting to EPSG:4326.')
+  if (!spatialReference && logWarning) console.log('WARNING: geometry filter spatial reference unknown. Defaulting to EPSG:4326.')
 
   return spatialReference || { wkid: 4326 }
 }


### PR DESCRIPTION
There was a faulty check in the geometry filter normalizer that was causes a warning to always get printed.