### PR TITLE
Add support for point geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* Add support for Point geometry filters
+
 ## [2.3.0] - 03-31-2021
 ### Added
 * Type definition file for TypeScript

--- a/lib/normalize-query-options/geometry-filter.js
+++ b/lib/normalize-query-options/geometry-filter.js
@@ -14,7 +14,7 @@ function normalizeGeometryFilter (options = {}) {
   const geometryFilterSpatialReference = normalizeGeometryFilterSpatialReference(options)
   const fromSR = getCrsString(geometryFilterSpatialReference)
 
-  const geometryFilter = transformGeometryToPolygon(geometry)
+  const geometryFilter = transformGeometryToGeojson(geometry)
 
   const dataCrs = normalizeSourceSR(options)
 
@@ -33,9 +33,17 @@ function normalizeGeometryFilter (options = {}) {
   return geometryFilter
 }
 
-function transformGeometryToPolygon (geometry) {
+function transformGeometryToGeojson (geometry) {
   if (_.isString(geometry) || Array.isArray(geometry)) {
     const coordinates = normalizeArray(geometry)
+
+    if (coordinates.length === 2) {
+      return {
+        type: 'Point',
+        coordinates: coordinates.map(Number)
+      }
+    }
+
     const { geometry: polygon } = bboxPolygon(coordinates)
     return polygon
   }

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -291,9 +291,9 @@ test('With a string-style geometry', t => {
   run('trees', options, 6, t)
 })
 
-test('With a point geometry', t => {
+test('With a point geometry filter', t => {
   const options = {
-    geometry: '-118.162307,34.137114'
+    geometry: '-118.16230746759626,34.137113646321595'
   }
   run('trees', options, 1, t)
 })

--- a/test/integration/filter.spec.js
+++ b/test/integration/filter.spec.js
@@ -291,6 +291,13 @@ test('With a string-style geometry', t => {
   run('trees', options, 6, t)
 })
 
+test('With a point geometry', t => {
+  const options = {
+    geometry: '-118.162307,34.137114'
+  }
+  run('trees', options, 1, t)
+})
+
 test('With a ST_Contains geometry predicate', t => {
   const options = {
     geometry: {

--- a/test/unit/normalize-query-options/geometry-filter.spec.js
+++ b/test/unit/normalize-query-options/geometry-filter.spec.js
@@ -141,7 +141,7 @@ test('normalize-query-options, geometry-filter: same data/filter spatial referen
   })
 })
 
-test('normalize-query-options, geometry-filter: geometry as coordinate string', t => {
+test('normalize-query-options, geometry-filter: geometry as coordinate string polygon', t => {
   t.plan(1)
   const geometryFilter = normalizeGeometryFilter({ geometry: '10,15,20,25' })
   t.deepEquals(geometryFilter, {
@@ -158,7 +158,16 @@ test('normalize-query-options, geometry-filter: geometry as coordinate string', 
   })
 })
 
-test('normalize-query-options, geometry-filter: geometry as coordinate array', t => {
+test('normalize-query-options, geometry-filter: geometry as coordinate string point', t => {
+  t.plan(1)
+  const geometryFilter = normalizeGeometryFilter({ geometry: '-10,10' })
+  t.deepEquals(geometryFilter, {
+    type: 'Point',
+    coordinates: [-10, 10]
+  })
+})
+
+test('normalize-query-options, geometry-filter: geometry as coordinate array polygon', t => {
   t.plan(1)
   const geometryFilter = normalizeGeometryFilter({ geometry: [10, 15, 20, 25] })
   t.deepEquals(geometryFilter, {
@@ -172,6 +181,15 @@ test('normalize-query-options, geometry-filter: geometry as coordinate array', t
         [10, 15]
       ]
     ]
+  })
+})
+
+test('normalize-query-options, geometry-filter: geometry as coordinate array point', t => {
+  t.plan(1)
+  const geometryFilter = normalizeGeometryFilter({ geometry: [-10, 10] })
+  t.deepEquals(geometryFilter, {
+    type: 'Point',
+    coordinates: [-10, 10]
   })
 })
 


### PR DESCRIPTION
Adds support for the `geometry` query param to be Point coordinates as specified by the `esriGeometryPoint` `geometryType` https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer-.htm

This prevents an error in koop when using geoservices output for a link like:
https://featureserver.com/provider/id/FeatureServer/0/query?f=json&geometryType=esriGeometryPoint&geometry=7652714.335571289%2C-1985856.184782909&geometryType=esriGeometryPoint&inSR=102100&outSR=102100

Added tests for this case, and monkey patched our version of koop to verify the fix works in our case.
Resolves https://github.com/koopjs/winnow/issues/203