### PR TITLE
Patch sql param generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+* Error in SQL param construction when returnGeometry=false but input and output CRS differ
+
 ## [2.3.0] - 03-31-2021
 ### Added
 * Type definition file for TypeScript

--- a/lib/sql-query-builder/create-sql-params.js
+++ b/lib/sql-query-builder/create-sql-params.js
@@ -29,14 +29,12 @@ function params (features, {
   return params
 }
 
-function shouldAddCrsParams (options = {}) {
-  const {
-    aggregates,
-    returnGeometry,
-    inputCrs,
-    outputCrs
-  } = options
-
+function shouldAddCrsParams ({
+  aggregates,
+  returnGeometry,
+  inputCrs,
+  outputCrs
+} = {}) {
   return !aggregates && returnGeometry !== false && isDifferentCrs(inputCrs, outputCrs)
 }
 

--- a/lib/sql-query-builder/create-sql-params.js
+++ b/lib/sql-query-builder/create-sql-params.js
@@ -1,15 +1,13 @@
 const isDifferentCrs = require('./is-different-crs')
 
-function params (features, options = {}) {
-  const {
-    returnGeometry,
-    inputCrs,
-    outputCrs,
-    aggregates,
-    geometry,
-    geometryPrecision
-  } = options
-
+function params (features, {
+  returnGeometry,
+  inputCrs,
+  outputCrs,
+  aggregates,
+  geometry,
+  geometryPrecision
+} = {}) {
   const params = []
   // NOTE: order matters here
   // select fragment: transform function parameters here

--- a/lib/sql-query-builder/create-sql-params.js
+++ b/lib/sql-query-builder/create-sql-params.js
@@ -1,0 +1,49 @@
+const isDifferentCrs = require('./is-different-crs')
+
+function params (features, options = {}) {
+  const {
+    returnGeometry,
+    inputCrs,
+    outputCrs,
+    aggregates,
+    geometry,
+    geometryPrecision
+  } = options
+
+  const params = []
+  // NOTE: order matters here
+  // select fragment: transform function parameters here
+  if (shouldAddCrsParams({ aggregates, returnGeometry, inputCrs, outputCrs })) {
+    params.push(getCrsString(inputCrs), getCrsString(outputCrs))
+  }
+
+  if (geometryPrecision) {
+    params.push(geometryPrecision)
+  }
+
+  // from fragment: features parameter here
+  params.push(Array.isArray(features) ? features : [features])
+
+  // where fragment: geometry filter parameter here
+  if (geometry) {
+    params.push(geometry)
+  }
+  return params
+}
+
+function shouldAddCrsParams (options = {}) {
+  const {
+    aggregates,
+    returnGeometry,
+    inputCrs,
+    outputCrs
+  } = options
+
+  return !aggregates && returnGeometry !== false && isDifferentCrs(inputCrs, outputCrs)
+}
+
+function getCrsString ({ wkt, wkid } = {}) {
+  return wkt || `EPSG:${wkid}`
+}
+
+module.exports = params

--- a/lib/sql-query-builder/create-sql-string.js
+++ b/lib/sql-query-builder/create-sql-string.js
@@ -1,0 +1,17 @@
+
+const createWhereClause = require('./where')
+const createSelectSql = require('./select')
+const createOrderByClause = require('./order-by')
+const createGroupByClause = require('./group-by')
+
+function create (options = {}) {
+  const select = createSelectSql(options)
+  const where = createWhereClause(options)
+  const orderBy = createOrderByClause(options)
+  const groupBy = createGroupByClause(options)
+  const limit = options.limit ? ` LIMIT ${options.limit}` : ''
+  const offset = options.offset ? ` OFFSET ${options.offset}` : ''
+  return `${select}${where}${groupBy}${orderBy}${limit}${offset}`
+}
+
+module.exports = create

--- a/lib/sql-query-builder/create-sql-string.js
+++ b/lib/sql-query-builder/create-sql-string.js
@@ -1,4 +1,3 @@
-
 const createWhereClause = require('./where')
 const createSelectSql = require('./select')
 const createOrderByClause = require('./order-by')

--- a/lib/sql-query-builder/index.js
+++ b/lib/sql-query-builder/index.js
@@ -1,42 +1,4 @@
-const createWhereClause = require('./where')
-const createSelectSql = require('./select')
-const createOrderByClause = require('./order-by')
-const createGroupByClause = require('./group-by')
-const isDifferentCrs = require('./is-different-crs')
-
-function create (options) {
-  const select = createSelectSql(options)
-  const where = createWhereClause(options)
-  const orderBy = createOrderByClause(options)
-  const groupBy = createGroupByClause(options)
-  const limit = options.limit ? ` LIMIT ${options.limit}` : ''
-  const offset = options.offset ? ` OFFSET ${options.offset}` : ''
-  return `${select}${where}${groupBy}${orderBy}${limit}${offset}`
+module.exports = {
+  create: require('./create-sql-string'),
+  params: require('./create-sql-params')
 }
-
-function params (features, { inputCrs, outputCrs, aggregates, geometry, geometryPrecision }) {
-  const params = []
-  // NOTE: order matters here
-  // select fragment: transform function parameters here
-  if (!aggregates && isDifferentCrs(inputCrs, outputCrs)) {
-    params.push(getCrsString(inputCrs), getCrsString(outputCrs))
-  }
-
-  if (geometryPrecision) {
-    params.push(geometryPrecision)
-  }
-
-  // from fragment: features parameter here
-  params.push(Array.isArray(features) ? features : [features])
-
-  // where fragment: geometry filter parameter here
-  if (geometry) {
-    params.push(geometry)
-  }
-  return params
-}
-
-function getCrsString ({ wkt, wkid } = {}) {
-  return wkt || `EPSG:${wkid}`
-}
-module.exports = { create, params }

--- a/test/unit/sql-query-builder/create-sql-params.spec.js
+++ b/test/unit/sql-query-builder/create-sql-params.spec.js
@@ -1,0 +1,52 @@
+const test = require('tape')
+const createSqlParams = require('../../../lib/sql-query-builder/create-sql-params')
+
+test('createSqlParams: returns features if no options', t => {
+  t.plan(1)
+  const params = createSqlParams(['feature'])
+  t.deepEquals(params, [['feature']])
+})
+
+test('createSqlParams: returns features and geometry filter', t => {
+  t.plan(1)
+  const params = createSqlParams(['feature'], { geometry: 'geom-filter' })
+  t.deepEquals(params, [['feature'], 'geom-filter'])
+})
+
+test('createSqlParams: returns geometry precision, features and geometry filter', t => {
+  t.plan(1)
+  const params = createSqlParams(['feature'], {
+    geometryPrecision: 'precision',
+    geometry: 'geom-filter'
+  })
+  t.deepEquals(params, ['precision', ['feature'], 'geom-filter'])
+})
+
+test('createSqlParams: returns crs, features if input/output crs different', t => {
+  t.plan(1)
+  const params = createSqlParams(['feature'], {
+    inputCrs: { wkid: 4326 },
+    outputCrs: { wkid: 3857 }
+  })
+  t.deepEquals(params, ['EPSG:4326', 'EPSG:3857', ['feature']])
+})
+
+test('createSqlParams: does not return crs, if returnGeometry===false', t => {
+  t.plan(1)
+  const params = createSqlParams(['feature'], {
+    returnGeometry: false,
+    inputCrs: { wkid: 4326 },
+    outputCrs: { wkid: 3857 }
+  })
+  t.deepEquals(params, [['feature']])
+})
+
+test('createSqlParams: does not return crs, if aggregates defined', t => {
+  t.plan(1)
+  const params = createSqlParams(['feature'], {
+    aggregates: true,
+    inputCrs: { wkid: 4326 },
+    outputCrs: { wkid: 3857 }
+  })
+  t.deepEquals(params, [['feature']])
+})

--- a/test/unit/sql-query-builder/create-sql-string.spec.js
+++ b/test/unit/sql-query-builder/create-sql-string.spec.js
@@ -1,0 +1,80 @@
+const test = require('tape')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire')
+
+const whereSpy = sinon.spy(function () {
+  return ' WHERE "substring"'
+})
+
+const selectSpy = sinon.spy(function () {
+  return 'SELECT "substring"'
+})
+
+const orderBySpy = sinon.spy(function () {
+  return ' ORDER BY "substring"'
+})
+
+const groupBySpy = sinon.spy(function () {
+  return ' GROUP BY "substring"'
+})
+
+const testCleanup = () => {
+  whereSpy.resetHistory()
+  selectSpy.resetHistory()
+  orderBySpy.resetHistory()
+  groupBySpy.resetHistory()
+}
+
+const createSqlString = proxyquire('../../../lib/sql-query-builder/create-sql-string', {
+  './where': whereSpy,
+  './select': selectSpy,
+  './order-by': orderBySpy,
+  './group-by': groupBySpy
+})
+
+test('createSqlString: with no options', t => {
+  t.plan(9)
+  testCleanup()
+  const sqlString = createSqlString()
+  t.equals(sqlString, 'SELECT "substring" WHERE "substring" GROUP BY "substring" ORDER BY "substring"')
+  t.equals(selectSpy.callCount, 1)
+  t.equals(whereSpy.callCount, 1)
+  t.equals(groupBySpy.callCount, 1)
+  t.equals(orderBySpy.callCount, 1)
+  t.deepEquals(selectSpy.firstCall.args, [{}])
+  t.deepEquals(whereSpy.firstCall.args, [{}])
+  t.deepEquals(groupBySpy.firstCall.args, [{}])
+  t.deepEquals(orderBySpy.firstCall.args, [{}])
+  testCleanup()
+})
+
+test('createSqlString: with limit and offset options', t => {
+  t.plan(9)
+  testCleanup()
+  const sqlString = createSqlString({
+    limit: 10,
+    offset: 20
+  })
+  t.equals(sqlString, 'SELECT "substring" WHERE "substring" GROUP BY "substring" ORDER BY "substring" LIMIT 10 OFFSET 20')
+  t.equals(selectSpy.callCount, 1)
+  t.equals(whereSpy.callCount, 1)
+  t.equals(groupBySpy.callCount, 1)
+  t.equals(orderBySpy.callCount, 1)
+  t.deepEquals(selectSpy.firstCall.args, [{
+    limit: 10,
+    offset: 20
+  }])
+  t.deepEquals(whereSpy.firstCall.args, [{
+    limit: 10,
+    offset: 20
+  }])
+  t.deepEquals(groupBySpy.firstCall.args, [{
+    limit: 10,
+    offset: 20
+  }])
+  t.deepEquals(orderBySpy.firstCall.args, [{
+    limit: 10,
+    offset: 20
+  }])
+  testCleanup()
+})


### PR DESCRIPTION
When `returnGeometry=false`, the generated SQL doesn't include call to reprojection function; As a result we should not add CRS arguments to the array of sql parameters.