### PR TITLE
Allow optional properties on incoming spatial reference.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+### Fixed
+* validation for spatial references
+
 ### Added
 * Add support for Point geometry filters
 

--- a/lib/normalize-query-options/spatial-reference.js
+++ b/lib/normalize-query-options/spatial-reference.js
@@ -11,7 +11,6 @@ const schema = Joi.alternatives(
     latestWkid: Joi.number().integer().optional(),
     wkt: Joi.string().optional()
   }).or('wkid', 'latestWkid', 'wkt')
-    .required()
     .unknown()
 )
 

--- a/lib/normalize-query-options/spatial-reference.js
+++ b/lib/normalize-query-options/spatial-reference.js
@@ -10,7 +10,9 @@ const schema = Joi.alternatives(
     wkid: Joi.number().integer().optional(),
     latestWkid: Joi.number().integer().optional(),
     wkt: Joi.string().optional()
-  }).or('wkid', 'latestWkid', 'wkt').required()
+  }).or('wkid', 'latestWkid', 'wkt')
+    .required()
+    .unknown()
 )
 
 function normalizeSpatialReference (input) {
@@ -54,7 +56,7 @@ function parseSpatialReferenceInput (spatialReference) {
   if (spatialReference.wkid || spatialReference.latestWkid) {
     return {
       type: 'wkid',
-      value: spatialReference.wkid || spatialReference.latestWkid
+      value: spatialReference.latestWkid || spatialReference.wkid
     }
   }
 

--- a/test/unit/normalize-query-options/spatial-reference.spec.js
+++ b/test/unit/normalize-query-options/spatial-reference.spec.js
@@ -126,3 +126,22 @@ test('normalize-query-options, spatial-reference: wkid not in Proj4 list', t => 
   t.equal(wkt, inputWkt)
   t.equal(wkid, 2855)
 })
+
+test('normalize-query-options, spatial-reference: object with wkid and other optional properties', t => {
+  t.plan(1)
+  const { wkid } = normalizeSpatialReference({
+    wkid: 102643,
+    latestWkid: 2227,
+    xyTolerance: 0.003280833333333333,
+    zTolerance: 0.001,
+    mTolerance: 0.001,
+    falseX: -115860600,
+    falseY: -93269500,
+    xyUnits: 3048.0060960121928,
+    falseZ: -100000,
+    zUnits: 10000,
+    falseM: -100000,
+    mUnits: 10000
+  })
+  t.equal(wkid, 2227)
+})


### PR DESCRIPTION
Spatial reference option currently fails validation if additional, but unused, properties are included.  This fixes https://github.com/koopjs/winnow/issues/191.