### PR TITLE
F/serialize nested properties when converting to Esri JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* Nested Esri JSON properties should be stringified
+
 ## [2.4.0] - 04-21-2022
 ### Changed
 * replace GPL-2.0 dependency flora-sql-parser with pgsql-ast-parser, which uses MIT

--- a/lib/filter-and-transform/transforms/to-esri-attributes.js
+++ b/lib/filter-and-transform/transforms/to-esri-attributes.js
@@ -1,11 +1,11 @@
+const _ = require('lodash')
 const { createIntegerHash } = require('../helpers')
 
-module.exports = function transformToEsriProperties (properties, geometry, dateFields, requiresObjectId, idField) {
+module.exports = function transformToEsriProperties (properties, geometry, delimitedDateFields, requiresObjectId, idField) {
   requiresObjectId = requiresObjectId === 'true'
   idField = idField === 'null' ? null : idField
-  const transformedDateFields = transformDateFields(properties, dateFields)
-  const transformedProperties = { ...properties, ...transformedDateFields }
-
+  const dateFields = delimitedDateFields.split(',')
+  const transformedProperties = serializeNestedProperties(properties, dateFields)
   if (requiresObjectId) {
     if (!idField) {
       const OBJECTID = createIntegerHash(JSON.stringify({ properties: transformedProperties, geometry }))
@@ -25,13 +25,15 @@ function shouldLogIdFieldWarning (idField) {
     (!Number.isInteger(idField) || idField > 2147483647)
 }
 
-function transformDateFields (properties, delimitedDateFields) {
-  if (delimitedDateFields.length === 0) return properties
-  const dateFields = delimitedDateFields.split(',')
-
-  return dateFields.reduce((acc, field) => {
-    const value = properties[field]
-    acc[field] = value === null ? null : new Date(value).getTime()
-    return acc
+function serializeNestedProperties (properties, dateFields) {
+  return Object.entries(properties).reduce((transformedProperties, [key, value]) => {
+    if (dateFields.includes(key)) {
+      transformedProperties[key] = value === null ? null : new Date(value).getTime()
+    } else if (_.isObject(value)) {
+      transformedProperties[key] = JSON.stringify(value)
+    } else {
+      transformedProperties[key] = value
+    }
+    return transformedProperties
   }, {})
 }

--- a/lib/filter-and-transform/transforms/to-esri-attributes.js
+++ b/lib/filter-and-transform/transforms/to-esri-attributes.js
@@ -1,22 +1,29 @@
 const _ = require('lodash')
 const { createIntegerHash } = require('../helpers')
 
-module.exports = function transformToEsriProperties (properties, geometry, delimitedDateFields, requiresObjectId, idField) {
+module.exports = function transformToEsriProperties (inputProperties, geometry, delimitedDateFields, requiresObjectId, idField) {
   requiresObjectId = requiresObjectId === 'true'
   idField = idField === 'null' ? null : idField
-  const dateFields = delimitedDateFields.split(',')
-  const transformedProperties = serializeNestedProperties(properties, dateFields)
-  if (requiresObjectId) {
-    if (!idField) {
-      const OBJECTID = createIntegerHash(JSON.stringify({ properties: transformedProperties, geometry }))
-      return { ...transformedProperties, OBJECTID }
-    }
 
-    if (shouldLogIdFieldWarning(properties[idField])) {
-      console.warn(`WARNING: OBJECTIDs created from provider's "idField" (${idField}: ${properties[idField]}) are not integers from 0 to 2147483647`)
-    }
+  const dateFields = delimitedDateFields.split(',')
+  const properties = transformProperties(inputProperties, dateFields)
+
+  if (requiresObjectId && !idField) {
+    return injectObjectId({ properties, geometry })
+  } else if (requiresObjectId && shouldLogIdFieldWarning(properties[idField])) {
+    console.warn(`WARNING: OBJECTIDs created from provider's "idField" (${idField}: ${inputProperties[idField]}) are not integers from 0 to 2147483647`)
   }
-  return transformedProperties
+
+  return properties
+}
+
+function injectObjectId (feature) {
+  const { properties } = feature
+  const OBJECTID = createIntegerHash(JSON.stringify(feature))
+  return {
+    ...properties,
+    OBJECTID
+  }
 }
 
 function shouldLogIdFieldWarning (idField) {
@@ -25,7 +32,7 @@ function shouldLogIdFieldWarning (idField) {
     (!Number.isInteger(idField) || idField > 2147483647)
 }
 
-function serializeNestedProperties (properties, dateFields) {
+function transformProperties (properties, dateFields) {
   return Object.entries(properties).reduce((transformedProperties, [key, value]) => {
     if (dateFields.includes(key)) {
       transformedProperties[key] = value === null ? null : new Date(value).getTime()

--- a/test/unit/filter-and-transform/transforms/to-esri-attributes.spec.js
+++ b/test/unit/filter-and-transform/transforms/to-esri-attributes.spec.js
@@ -38,3 +38,19 @@ test('toEsriAttributes, does not require idField, has dateFields', t => {
   t.deepEquals(result, { hello: 'world', foo: date1.getTime(), bar: date2.getTime() })
   t.end()
 })
+
+test('toEsriAttributes, does not require idField, has nested properties', t => {
+  const result = toEsriAttributes({
+    hello: 'world',
+    nested: {
+      foo: 'bar'
+    }
+  }, {
+    coordinates: [-118, 34]
+  },
+  '',
+  'false',
+  '')
+  t.deepEquals(result, { hello: 'world', nested: '{"foo":"bar"}' })
+  t.end()
+})


### PR DESCRIPTION
The transform-to-esri feature should stringify any nested GeoJSON properties. This is confirmed by looking at responses from AGO services. So something like:

```js
"nested": {
  "foo": "bar"
}
```

should become:

```js
"nested": "{\"foo\":\"bar\"}"
```
