### PR TITLE
Add support for DISTINCT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+* add support for SELECT DISTINCT queries
+
 ## [2.5.2] - 08-05-2022
 ### Changed
 * bump terraformer version

--- a/lib/sql-query-builder/select/index.js
+++ b/lib/sql-query-builder/select/index.js
@@ -8,14 +8,16 @@ function createSelectSql (options = {}) {
   return createStandardSelect(options)
 }
 
-function createStandardSelect (options = {}) {
+function createStandardSelect (options) {
+  const select = options.distinct ? 'SELECT DISTINCT' : 'SELECT'
+
   const fieldsList = createFieldsSelectFragment(options)
 
   if (options.returnGeometry === false) {
-    return (`SELECT ${fieldsList} FROM ?`)
+    return (`${select} ${fieldsList} FROM ?`)
   }
 
-  return (`SELECT ${fieldsList}, ${createGeometrySelectFragment(options)} FROM ?`)
+  return (`${select} ${fieldsList}, ${createGeometrySelectFragment(options)} FROM ?`)
 }
 
 module.exports = createSelectSql

--- a/test/unit/sql-query-builder/select/index.spec.js
+++ b/test/unit/sql-query-builder/select/index.spec.js
@@ -30,3 +30,9 @@ test('createSelectSql: returnGeometry:false option', async (spec) => {
   const result = createSelectSql({ returnGeometry: false })
   spec.equals(result, 'SELECT fields fragment FROM ?')
 })
+
+test('createSelectSql: distinct:true option', async (spec) => {
+  spec.plan(1)
+  const result = createSelectSql({ distinct: true, returnGeometry: false })
+  spec.equals(result, 'SELECT DISTINCT fields fragment FROM ?')
+})


### PR DESCRIPTION
This PR adds support for queries with the `DISTINCT` operator.   Note this is the same change as https://github.com/koopjs/koop/pull/467, but ported here for users of the deprecated library.